### PR TITLE
Add support for AppRole auth method. Add support for configuration file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ data.
 
 ## Setup
 
+`vault_lookup` function can be configured to use Vault Cert or AppRole auth
+methods.
+
+### Vault Cert auth method
+
 The `vault_lookup` function uses the Puppet agent's certificates in order to
 authenticate to the Vault server; this means that before any agents contact a
 Vault server, you must configure the Vault server with the Puppet Server's CA
@@ -76,6 +81,22 @@ $ vault write auth/cert/certs/puppetserver \
 Once the certificate has been uploaded, any Puppet agent with a signed
 certificate will be able to authenticate with Vault.
 
+### Vault AppRole auth method
+
+To use AppRole auth method a configuration file must be used. Configuration
+file should be placed at `{puppet-config-dir}/vault-lookup.yaml` where `{puppet-config-dir}`
+is usually `/etc/puppetlabs/puppet` on Linux systems.
+
+Configuration file syntax is:
+
+```yaml
+---
+VAULT_ADDR: <Vault server URI, including http schema and port>
+AUTH_METHOD: <'cert' | 'approle'>
+VAULT_ROLE_ID: <Vault role ID if using approle method>
+VAULT_SECRET_ID: <Vault secret ID if using approle method>
+```
+
 ## Usage
 
 Install this module as you would in any other; the necessary code will
@@ -100,9 +121,9 @@ resolved when the catalog is applied. This will make a call to
 `Sensitive` type, which prevents the value from being logged.
 
 You can also choose not to specify the Vault URL, and then Puppet will use the
-`VAULT_ADDR` environment variable. This will be either set on the command line, or
-set in the service config file for Puppet, on Debian `/etc/default/puppet`, on RedHat
-`/etc/sysconfig/puppet`:
+value defined in configuration file or `VAULT_ADDR` environment variable. This will
+be either set on the command line, or set in the service config file for
+Puppet, on Debian `/etc/default/puppet`, on RedHat `/etc/sysconfig/puppet`:
 
 ```
 $d = Deferred('vault_lookup::lookup', ["secret/test"])

--- a/lib/puppet/functions/vault_lookup/lookup.rb
+++ b/lib/puppet/functions/vault_lookup/lookup.rb
@@ -36,7 +36,7 @@ Puppet::Functions.create_function(:'vault_lookup::lookup') do
     if vault_url.nil?
       Puppet.debug 'No Vault address was set on function, defaulting to value from VAULT_ADDR env value or config file'
       vault_url = VAULT_ADDR
-      raise Puppet::Error, "No vault_url given and VAULT_ADDR not provided, #{VAULT_ADDR}, #{AUTH_METHOD}" if vault_url.nil?
+      raise Puppet::Error, 'No vault_url given and VAULT_ADDR not provided' if vault_url.nil?
     end
 
     uri = URI(vault_url)
@@ -79,18 +79,14 @@ Puppet::Functions.create_function(:'vault_lookup::lookup') do
     if AUTH_METHOD == 'cert'
       response = connection.post('/v1/auth/cert/login', '')
     elsif AUTH_METHOD == 'approle'
-      begin
-        response = connection.post(
-          '/v1/auth/approle/login',
-          {
-            'role_id'   => VAULT_ROLE_ID,
-            'secret_id' => VAULT_SECRET_ID
-          }.to_json,
-          'Content-Type' => 'application/json',
-        )
-      rescue StandardError => e
-        raise Puppet::Error, "Failed performing login request, #{e.backtrace.first}: #{e.message} (#{e.class})"
-      end
+      response = connection.post(
+        '/v1/auth/approle/login',
+        {
+          'role_id'   => VAULT_ROLE_ID,
+          'secret_id' => VAULT_SECRET_ID
+        }.to_json,
+        'Content-Type' => 'application/json',
+      )
     else
       raise Puppet::Error, 'Vault auth method not supported'
     end

--- a/lib/puppet/functions/vault_lookup/lookup.rb
+++ b/lib/puppet/functions/vault_lookup/lookup.rb
@@ -1,14 +1,42 @@
+require 'puppet'
+require 'puppet/util'
+require 'yaml'
+require 'fileutils'
+require 'net/http'
+
 Puppet::Functions.create_function(:'vault_lookup::lookup') do
   dispatch :lookup do
     param 'String', :path
     optional_param 'String', :vault_url
   end
 
+  configfile = File.join([File.dirname(Puppet.settings[:config]),
+                          'vault-lookup.yaml'])
+
+  AUTH_METHOD = 'cert'
+  VAULT_ADDR = ENV['VAULT_ADDR']
+  VAULT_ROLE_ID = ''
+  VAULT_SECRET_ID = ''
+
+  if File.exist?(configfile)
+    config = YAML.load_file(configfile)
+    AUTH_METHOD = config['AUTH_METHOD'] if config.key?('AUTH_METHOD')
+    VAULT_ADDR = config['VAULT_ADDR'] if config.key?('VAULT_ADDR')
+    VAULT_ROLE_ID = config['VAULT_ROLE_ID'] if config.key?('VAULT_ROLE_ID')
+    VAULT_SECRET_ID = config['VAULT_SECRET_ID'] if config.key?('VAULT_SECRET_ID')
+  else
+    Puppet.debug "Configuration file #{configfile} not found, using defaults"
+  end
+
+  unless ['cert', 'approle'].include?(AUTH_METHOD)
+    raise(Puppet::Error, "vault_lookup auth method #{AUTH_METHOD} not supported, use one of cert or approle")
+  end
+
   def lookup(path, vault_url = nil)
     if vault_url.nil?
-      Puppet.debug 'No Vault address was set on function, defaulting to value from VAULT_ADDR env value'
-      vault_url = ENV['VAULT_ADDR']
-      raise Puppet::Error, 'No vault_url given and VAULT_ADDR env variable not set' if vault_url.nil?
+      Puppet.debug 'No Vault address was set on function, defaulting to value from VAULT_ADDR env value or config file'
+      vault_url = VAULT_ADDR
+      raise Puppet::Error, "No vault_url given and VAULT_ADDR not provided, #{VAULT_ADDR}, #{AUTH_METHOD}" if vault_url.nil?
     end
 
     uri = URI(vault_url)
@@ -19,7 +47,14 @@ Puppet::Functions.create_function(:'vault_lookup::lookup') do
     raise Puppet::Error, "Unable to parse a hostname from #{vault_url}" unless uri.hostname
 
     use_ssl = uri.scheme == 'https'
-    connection = Puppet::Network::HttpPool.http_instance(uri.host, uri.port, use_ssl)
+
+    if AUTH_METHOD == 'cert'
+      connection = Puppet::Network::HttpPool.http_instance(uri.host, uri.port, use_ssl)
+    elsif AUTH_METHOD == 'approle'
+      # When using approle, Vault server certificate doesn't have to match
+      # puppet CA, so we use a plain Net::HTTP connection here
+      connection = Net::HTTP.start(uri.host, uri.port, :use_ssl => use_ssl)
+    end
 
     token = get_auth_token(connection)
 
@@ -41,7 +76,25 @@ Puppet::Functions.create_function(:'vault_lookup::lookup') do
   private
 
   def get_auth_token(connection)
-    response = connection.post('/v1/auth/cert/login', '')
+    if AUTH_METHOD == 'cert'
+      response = connection.post('/v1/auth/cert/login', '')
+    elsif AUTH_METHOD == 'approle'
+      begin
+        response = connection.post(
+          '/v1/auth/approle/login',
+          {
+            'role_id'   => VAULT_ROLE_ID,
+            'secret_id' => VAULT_SECRET_ID
+          }.to_json,
+          'Content-Type' => 'application/json',
+        )
+      rescue StandardError => e
+        raise Puppet::Error, "Failed performing login request, #{e.backtrace.first}: #{e.message} (#{e.class})"
+      end
+    else
+      raise Puppet::Error, 'Vault auth method not supported'
+    end
+
     unless response.is_a?(Net::HTTPOK)
       message = "Received #{response.code} response code from vault at #{connection.address} for authentication"
       raise Puppet::Error, append_api_errors(message, response)


### PR DESCRIPTION
This PR adds support to use AppRole Vault's auth method.
It also adds support for configuring `vault_lookup` function using a configuration file as in https://github.com/voxpupuli/puppet-prometheus_reporter/blob/master/lib/puppet/reports/prometheus.rb#L12