### PR TITLE
Add path information for related lookup errors

### DIFF
--- a/lib/puppet/functions/vault_lookup/lookup.rb
+++ b/lib/puppet/functions/vault_lookup/lookup.rb
@@ -25,14 +25,14 @@ Puppet::Functions.create_function(:'vault_lookup::lookup') do
 
     secret_response = connection.get("/v1/#{path}", 'X-Vault-Token' => token)
     unless secret_response.is_a?(Net::HTTPOK)
-      message = "Received #{secret_response.code} response code from vault at #{uri.host} for secret lookup"
+      message = "Received #{secret_response.code} response code from vault at #{uri.host} for #{path} lookup"
       raise Puppet::Error, append_api_errors(message, secret_response)
     end
 
     begin
       data = JSON.parse(secret_response.body)['data']
     rescue StandardError
-      raise Puppet::Error, 'Error parsing json secret data from vault response'
+      raise Puppet::Error, "Error parsing json secret data from vault response for #{path} path"
     end
 
     Puppet::Pops::Types::PSensitiveType::Sensitive.new(data)


### PR DESCRIPTION
#### Pull Request (PR) description
Adds path information for data lookup errors when needed

As of now when puppet fails to apply catalog vault_lookup returns message with no clue where error happens:

`Error: Failed to apply catalog: Received 403 response code from vault at vault.local for secret lookup (api errors: ["1 error occurred:\n\t* permission denied\n\n"])`

With proposed change you can see which lookup actually related to the problem:

`Error: Failed to apply catalog: Received 403 response code from vault at vault.local for secret/data/puppet/service/graylog/s1/config lookup (api errors: ["1 error occurred:\n\t* permission denied\n\n"])`
