### PR TITLE
Port to use the new http client where available

### DIFF
--- a/lib/puppet/functions/vault_lookup/lookup.rb
+++ b/lib/puppet/functions/vault_lookup/lookup.rb
@@ -18,7 +18,7 @@ Puppet::Functions.create_function(:'vault_lookup::lookup') do
     # host is defined.
     raise Puppet::Error, "Unable to parse a hostname from #{vault_url}" unless uri.hostname
 
-    if defined? Puppet.runtime
+    if defined? Puppet.runtime && Puppet.runtime[:http]
       # modern Puppet HTTP client. This allows us to use the system store on >= 7.16.0
       connection = Puppet.runtime[:http]
       token = get_auth_token(connection, vault_url)

--- a/lib/puppet/functions/vault_lookup/lookup.rb
+++ b/lib/puppet/functions/vault_lookup/lookup.rb
@@ -20,9 +20,9 @@ Puppet::Functions.create_function(:'vault_lookup::lookup') do
 
     if defined? Puppet.runtime
       # modern Puppet HTTP client. This allows us to use the system store on >= 7.16.0
-      connection   = Puppet.runtime[:http]
+      connection = Puppet.runtime[:http]
       token = get_auth_token(connection, vault_url)
-      secret_response = connection.get(URI("#{vault_url}/v1/#{path}"), headers: {'X-Vault-Token' => token}, options: { include_system_store: true })
+      secret_response = connection.get(URI("#{vault_url}/v1/#{path}"), headers: { 'X-Vault-Token' => token }, options: { include_system_store: true })
 
       unless secret_response.success?
         message = "Received #{secret_response.code} response code from vault at #{uri.host} for secret lookup"
@@ -56,9 +56,9 @@ Puppet::Functions.create_function(:'vault_lookup::lookup') do
   def get_auth_token(connection, vault_url)
     if defined? Puppet.runtime
       response = connection.post(URI("#{vault_url}/v1/auth/cert/login"),
-                                  '',
-                                  headers: {'Content-Type' => 'application/json'},
-                                  options: { include_system_store: true })
+                                 '',
+                                 headers: { 'Content-Type' => 'application/json' },
+                                 options: { include_system_store: true })
 
       unless response.success?
         message = "Received #{response.code} response code from vault at #{connection.address} for authentication"

--- a/lib/puppet/functions/vault_lookup/lookup.rb
+++ b/lib/puppet/functions/vault_lookup/lookup.rb
@@ -54,7 +54,7 @@ Puppet::Functions.create_function(:'vault_lookup::lookup') do
   private
 
   def get_auth_token(connection, vault_url)
-    if defined? Puppet.runtime
+    if defined? Puppet.runtime && Puppet.runtime[:http]
       response = connection.post(URI("#{vault_url}/v1/auth/cert/login"),
                                  '',
                                  headers: { 'Content-Type' => 'application/json' },

--- a/spec/functions/lookup_spec.rb
+++ b/spec/functions/lookup_spec.rb
@@ -101,7 +101,7 @@ describe 'vault_lookup::lookup' do
 
       expect {
        function.execute('thepath', 'https://vault.doesnotexist:8200')
-     }.to raise_error(Puppet::Error, %r{Received 403 response code from vault.*invalid certificate or no client certificate supplied})
+      }.to raise_error(Puppet::Error, %r{Received 403 response code from vault.*invalid certificate or no client certificate supplied})
     end
   end
 


### PR DESCRIPTION
Puppet added a new http client in version 6.11. There wasn't a
compelling reason to port this, until 7.16 when that http client gained
the ability to use the system CA store. This meant that it could begin
trusting certificates not issued by Puppet's CA.

This conditionally ports to the new client where available, and uses the
system CA store as of 7.16.

Co-authored-by: vamsinm <vamsi.nainavarapu.vaap9t@statefarm.com>
Co-authored-by: Christos Papageorgiou <christos.papageorgioy@gmail.com>
Co-authored-by: Josh Cooper <737664+joshcooper@users.noreply.github.com>