### PR TITLE
(MODULES-11321) Use new Puppet http runtime; require Puppet 6.11 or newer

### DIFF
--- a/lib/puppet/functions/vault_lookup/lookup.rb
+++ b/lib/puppet/functions/vault_lookup/lookup.rb
@@ -2,8 +2,9 @@ Puppet::Functions.create_function(:'vault_lookup::lookup') do
   dispatch :lookup do
     param 'String', :path
     optional_param 'String', :vault_url
-    optional_param 'Variant[String,Undef]', :vault_cert_path_segment
+    optional_param 'Optional[String]', :vault_cert_path_segment
     optional_param 'String', :vault_cert_role
+    return_type 'Sensitive'
   end
 
   DEFAULT_CERT_PATH_SEGMENT = 'v1/auth/cert/'.freeze

--- a/lib/puppet/functions/vault_lookup/lookup.rb
+++ b/lib/puppet/functions/vault_lookup/lookup.rb
@@ -2,48 +2,82 @@ Puppet::Functions.create_function(:'vault_lookup::lookup') do
   dispatch :lookup do
     param 'String', :path
     optional_param 'String', :vault_url
+    optional_param 'Variant[String,Undef]', :vault_cert_path_segment
+    optional_param 'String', :vault_cert_role
   end
 
-  def lookup(path, vault_url = nil)
+  DEFAULT_CERT_PATH_SEGMENT = 'v1/auth/cert/'.freeze
+
+  def lookup(path,
+             vault_url = nil,
+             vault_cert_path_segment = nil,
+             vault_cert_role = nil)
     if vault_url.nil?
       Puppet.debug 'No Vault address was set on function, defaulting to value from VAULT_ADDR env value'
       vault_url = ENV['VAULT_ADDR']
       raise Puppet::Error, 'No vault_url given and VAULT_ADDR env variable not set' if vault_url.nil?
     end
 
-    uri = URI(vault_url)
-    # URI is used here to just parse the vault_url into a host string
+    if vault_cert_path_segment.nil?
+      vault_cert_path_segment = DEFAULT_CERT_PATH_SEGMENT
+    end
+
+    vault_base_uri = URI(vault_url)
+    # URI is used here to parse the vault_url into a host string
     # and port; it's possible to generate a URI::Generic when a scheme
     # is not defined, so double check here to make sure at least
     # host is defined.
-    raise Puppet::Error, "Unable to parse a hostname from #{vault_url}" unless uri.hostname
+    raise Puppet::Error, "Unable to parse a hostname from #{vault_url}" unless vault_base_uri.hostname
 
-    use_ssl = uri.scheme == 'https'
-    connection = Puppet::Network::HttpPool.http_instance(uri.host, uri.port, use_ssl)
+    client = Puppet.runtime[:http]
+    token = get_cert_auth_token(client,
+                                vault_base_uri,
+                                vault_cert_path_segment,
+                                vault_cert_role)
 
-    token = get_auth_token(connection)
-
-    secret_response = connection.get("/v1/#{path}", 'X-Vault-Token' => token)
-    unless secret_response.is_a?(Net::HTTPOK)
-      message = "Received #{secret_response.code} response code from vault at #{uri.host} for secret lookup"
-      raise Puppet::Error, append_api_errors(message, secret_response)
-    end
-
-    begin
-      data = JSON.parse(secret_response.body)['data']
-    rescue StandardError
-      raise Puppet::Error, 'Error parsing json secret data from vault response'
-    end
-
+    secret_uri = vault_base_uri + "/v1/#{path.delete_prefix('/')}"
+    data = get_secret(client, secret_uri, token)
     Puppet::Pops::Types::PSensitiveType::Sensitive.new(data)
   end
 
   private
 
-  def get_auth_token(connection)
-    response = connection.post('/v1/auth/cert/login', '')
-    unless response.is_a?(Net::HTTPOK)
-      message = "Received #{response.code} response code from vault at #{connection.address} for authentication"
+  def auth_login_body(vault_cert_role)
+    if vault_cert_role
+      { name: vault_cert_role }.to_json
+    else
+      ''
+    end
+  end
+
+  def get_secret(client, uri, token)
+    secret_response = client.get(uri, headers: { 'X-Vault-Token' => token })
+    unless secret_response.success?
+      message = "Received #{secret_response.code} response code from vault at #{uri} for secret lookup"
+      raise Puppet::Error, append_api_errors(message, secret_response)
+    end
+    begin
+      JSON.parse(secret_response.body)['data']
+    rescue StandardError
+      raise Puppet::Error, 'Error parsing json secret data from vault response'
+    end
+  end
+
+  def get_cert_auth_token(client, vault_url, vault_cert_path_segment, vault_cert_role)
+    role_data = auth_login_body(vault_cert_role)
+    headers = { 'Content-Type' => 'application/json' }
+    segment = if vault_cert_path_segment.end_with?('/')
+                vault_cert_path_segment
+              else
+                vault_cert_path_segment + '/'
+              end
+    login_url = vault_url + segment + 'login'
+    response = client.post(login_url,
+                           role_data,
+                           headers: headers,
+                           options: { include_system_store: true })
+    unless response.success?
+      message = "Received #{response.code} response code from vault at #{login_url} for authentication"
       raise Puppet::Error, append_api_errors(message, response)
     end
 

--- a/metadata.json
+++ b/metadata.json
@@ -83,7 +83,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.1.0 < 8.0.0"
+      "version_requirement": ">= 6.16.0 < 8.0.0"
     }
   ]
 }

--- a/spec/acceptance/fixtures/env_value/site.pp
+++ b/spec/acceptance/fixtures/env_value/site.pp
@@ -1,5 +1,5 @@
 $var = {
-  'd' => Deferred('vault_lookup::lookup', ["secret/test"])
+  'd' => Deferred('vault_lookup::lookup', ["kv/test"])
 }
 
 node default {

--- a/spec/acceptance/fixtures/intermediate_ca_openssl.cnf
+++ b/spec/acceptance/fixtures/intermediate_ca_openssl.cnf
@@ -28,6 +28,7 @@ default_crl_days  = 30
 # SHA-1 is deprecated, so use SHA-2 instead.
 default_md        = sha256
 
+copy_extensions   = copy
 name_opt          = ca_default
 cert_opt          = ca_default
 default_days      = 375

--- a/spec/acceptance/fixtures/site.pp
+++ b/spec/acceptance/fixtures/site.pp
@@ -1,5 +1,5 @@
 $var = {
-  'd' => Deferred('vault_lookup::lookup',["secret/test", 'https://vault.local:8200']),
+  'd' => Deferred('vault_lookup::lookup',["kv/test", 'https://vault.local:8200']),
 }
 
 node default {

--- a/spec/acceptance/fixtures/unseal.sh
+++ b/spec/acceptance/fixtures/unseal.sh
@@ -14,10 +14,10 @@ export VAULT_TOKEN
 
 vault operator unseal "$VAULT_KEY"
 
-echo "Create secret_reader policy that can read from secret/*"
+echo "Create secret_reader policy that can read from kv/*"
 
 vault policy write secret_reader - <<EOF
-path "secret/*" {
+path "kv/*" {
     capabilities = ["read"]
 }
 EOF
@@ -27,8 +27,8 @@ echo "Adding cert auth paths."
 
 vault auth enable cert
 
-vault write auth/cert/certs/vault.docker display_name='puppet cert' certificate=@/vault/config/certbundle.pem policies=secret_reader
+vault write auth/cert/certs/vault.docker display_name='puppet cert' certificate=@/vault/config/certbundle.pem token_policies=secret_reader
 
 echo 'Write secret/test: foo=bar'
-
-vault write secret/test foo=bar
+vault secrets enable -version=1 kv
+vault kv put kv/test foo=bar

--- a/spec/acceptance/fixtures/vault_config.hcl
+++ b/spec/acceptance/fixtures/vault_config.hcl
@@ -1,4 +1,5 @@
 {
+  "disable_mlock": true,
   "backend": {
     "file": {
       "path": "/vault/file"

--- a/spec/acceptance/lookup_spec.rb
+++ b/spec/acceptance/lookup_spec.rb
@@ -19,7 +19,7 @@ describe 'lookup with vault configured to accept certs from puppetserver' do
       opts = { desired_exit_codes: [0], max_retries: 60, retry_interval: 1 }
       retry_on(
         master,
-        "/opt/puppetlabs/puppet/bin/curl --insecure --fail \"https://127.0.0.1:8140/production/status/test\" | grep -q '\"is_alive\":true'",
+        '/opt/puppetlabs/puppet/bin/curl --insecure --fail https://127.0.0.1:8140/status/v1/simple | grep running',
         opts,
       )
     end

--- a/spec/acceptance/nodesets/docker/CertsDockerfile
+++ b/spec/acceptance/nodesets/docker/CertsDockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.9
 
 
 # Install openssl
@@ -50,6 +50,7 @@ RUN openssl genrsa -out intermediate/private/vault.key.pem 2048
 RUN openssl req -config intermediate/openssl.cnf \
       -key intermediate/private/vault.key.pem \
       -subj "/CN=vault.local" \
+      -addext "subjectAltName = DNS:vault.local" \
       -new -sha256 -out intermediate/csr/vault.csr.pem
 RUN openssl ca -config intermediate/openssl.cnf \
       -extensions server_cert -days 375 -batch -notext -md sha256 \

--- a/spec/acceptance/nodesets/docker/PuppetserverDockerfile
+++ b/spec/acceptance/nodesets/docker/PuppetserverDockerfile
@@ -1,6 +1,6 @@
 FROM certs:latest as certs
 
-FROM puppet/puppetserver:6.14.1
+FROM puppet/puppetserver:7.8.0
 
 COPY --from=certs /root/ca/intermediate/private/intermediate.key.pem /root/intermediate.key.pem
 COPY --from=certs /root/ca/intermediate/crl/crlchain.pem /root/crlchain.pem

--- a/spec/acceptance/nodesets/docker/VaultDockerfile
+++ b/spec/acceptance/nodesets/docker/VaultDockerfile
@@ -9,4 +9,6 @@ COPY --from=certs /root/ca/intermediate/private/vault.key.pem /vault/config/vaul
 COPY --from=certs /root/ca/intermediate/certs/vault.cert.pem /vault/config/vault.cert
 COPY --from=certs /root/ca/intermediate/certs/ca-bundle.cert.pem /vault/config/certbundle.pem
 
+RUN chown -R vault:vault /vault
+
 CMD ["server"]

--- a/spec/acceptance/nodesets/docker/VaultDockerfile
+++ b/spec/acceptance/nodesets/docker/VaultDockerfile
@@ -1,5 +1,5 @@
 FROM certs:latest as certs
-FROM vault:0.11.0
+FROM vault:1.10.0
 
 COPY spec/acceptance/fixtures/vault_config.hcl /vault/config/vault_config.hcl
 

--- a/spec/functions/lookup_spec.rb
+++ b/spec/functions/lookup_spec.rb
@@ -30,10 +30,10 @@ describe 'vault_lookup::lookup' do
   it 'raises a Puppet error when data lookup fails' do
     vault_server = MockVault.new
     vault_server.mount('/v1/auth/cert/login', AuthSuccess)
-    vault_server.mount('/v1/secret/test', SecretLookupDenied)
+    vault_server.mount('/v1/kv/test', SecretLookupDenied)
     vault_server.start_vault do |port|
       expect {
-        function.execute('secret/test', "http://127.0.0.1:#{port}")
+        function.execute('kv/test', "http://127.0.0.1:#{port}")
       }.to raise_error(Puppet::Error, %r{Received 403 response code from vault at .* for secret lookup.*permission denied})
     end
   end
@@ -41,10 +41,10 @@ describe 'vault_lookup::lookup' do
   it 'raises a Puppet error when warning present' do
     vault_server = MockVault.new
     vault_server.mount('/v1/auth/cert/login', AuthSuccess)
-    vault_server.mount('/v1/secret/test', SecretLookupWarning)
+    vault_server.mount('/v1/kv/test', SecretLookupWarning)
     vault_server.start_vault do |port|
       expect {
-        function.execute('secret/test', "http://127.0.0.1:#{port}")
+        function.execute('kv/test', "http://127.0.0.1:#{port}")
       }.to raise_error(Puppet::Error, %r{Received 404 response code from vault at .* for secret lookup.*Invalid path for a versioned K/V secrets engine})
     end
   end
@@ -52,9 +52,9 @@ describe 'vault_lookup::lookup' do
   it 'logs on, requests a secret using a token, and returns the data wrapped in the Sensitive type' do
     vault_server = MockVault.new
     vault_server.mount('/v1/auth/cert/login', AuthSuccess)
-    vault_server.mount('/v1/secret/test', SecretLookupSuccess)
+    vault_server.mount('/v1/kv/test', SecretLookupSuccess)
     vault_server.start_vault do |port|
-      result = function.execute('secret/test', "http://127.0.0.1:#{port}")
+      result = function.execute('kv/test', "http://127.0.0.1:#{port}")
       expect(result).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
       expect(result.unwrap).to eq('foo' => 'bar')
     end
@@ -63,9 +63,9 @@ describe 'vault_lookup::lookup' do
   it 'is successful when providing a cert_role while authenticating' do
     vault_server = MockVault.new
     vault_server.mount('/v1/auth/cert/login', AuthSuccessWithRole)
-    vault_server.mount('/v1/secret/test', SecretLookupSuccess)
+    vault_server.mount('/v1/kv/test', SecretLookupSuccess)
     vault_server.start_vault do |port|
-      result = function.execute('secret/test', "http://127.0.0.1:#{port}", nil, 'test-cert-role')
+      result = function.execute('kv/test', "http://127.0.0.1:#{port}", nil, 'test-cert-role')
       expect(result).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
       expect(result.unwrap).to eq('foo' => 'bar')
     end
@@ -75,9 +75,9 @@ describe 'vault_lookup::lookup' do
     custom_auth_segment = 'v1/custom/auth/segment'
     vault_server = MockVault.new
     vault_server.mount("/#{custom_auth_segment}/login", AuthSuccess)
-    vault_server.mount('/v1/secret/test', SecretLookupSuccess)
+    vault_server.mount('/v1/kv/test', SecretLookupSuccess)
     vault_server.start_vault do |port|
-      result = function.execute('secret/test', "http://127.0.0.1:#{port}", custom_auth_segment)
+      result = function.execute('kv/test', "http://127.0.0.1:#{port}", custom_auth_segment)
       expect(result).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
       expect(result.unwrap).to eq('foo' => 'bar')
     end
@@ -86,10 +86,10 @@ describe 'vault_lookup::lookup' do
   it 'logs on, requests a secret using a token, and returns the data wrapped in the Sensitive type from VAULT_ADDR' do
     vault_server = MockVault.new
     vault_server.mount('/v1/auth/cert/login', AuthSuccess)
-    vault_server.mount('/v1/secret/test', SecretLookupSuccess)
+    vault_server.mount('/v1/kv/test', SecretLookupSuccess)
     vault_server.start_vault do |port|
       stub_const('ENV', ENV.to_hash.merge('VAULT_ADDR' => "http://127.0.0.1:#{port}"))
-      result = function.execute('secret/test')
+      result = function.execute('kv/test')
       expect(result).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
       expect(result.unwrap).to eq('foo' => 'bar')
     end

--- a/spec/functions/lookup_spec.rb
+++ b/spec/functions/lookup_spec.rb
@@ -1,62 +1,9 @@
 require 'spec_helper'
+require 'mock_vault_helper'
 
+include PuppetVaultLookupHelpers
 describe 'vault_lookup::lookup' do
   let(:function) { subject }
-
-  let(:auth_success_data) do
-    <<~JSON
-      {
-        "request_id": "03d11bd4-b994-c432-150f-5703a75641d1",
-        "lease_id": "",
-        "renewable": false,
-        "lease_duration": 0,
-        "data": null,
-        "wrap_info": null,
-        "warnings": null,
-        "auth": {
-          "client_token": "7dad29d2-40af-038f-cf9c-0aeb616f8d20",
-          "accessor": "fd0c3269-9642-25e5-cebe-27a732be53a0",
-          "policies": [
-            "default",
-            "secret_reader"
-          ],
-          "token_policies": [
-            "default",
-            "secret_reader"
-          ],
-          "metadata": {
-            "authority_key_id": "b7:da:18:2f:cc:09:18:5d:d0:c5:24:0a:0a:66:46:ba:0d:f0:ea:4a",
-            "cert_name": "vault.docker",
-            "common_name": "localhost",
-            "serial_number": "5",
-            "subject_key_id": "ea:00:c0:0b:2d:38:01:28:ba:16:1f:08:64:de:0a:7c:8f:b7:43:33"
-          },
-          "lease_duration": 604800,
-          "renewable": true,
-          "entity_id": "e1bc06c5-303e-eec7-bf58-2a74fae2ec3d"
-        }
-      }
-    JSON
-  end
-
-  let(:auth_failure_data) do
-    '{"errors":["invalid certificate or no client certificate supplied"]}'
-  end
-
-  let(:secret_success_data) do
-    '{"request_id":"e394e8ef-78f3-ac85-fbeb-33f060e911d4","lease_id":"","renewable":false,"lease_duration":604800,"data":{"foo":"bar"},"wrap_info":null,"warnings":null,"auth":null}
-'
-  end
-
-  let(:permission_denied_data) do
-    '{"errors":["permission denied"]}'
-  end
-
-  let(:warnings_data) do
-    # rubocop:disable Metrics/LineLength
-    '{"request_id":"0971a3db-f77a-4b0f-224d-35ff3e05d23d","lease_id":"","renewable":false,"lease_duration":0,"data":null,"wrap_info":null,"warnings":["Invalid path for a versioned K/V secrets engine. See the API docs for the appropriate API endpoints to use. If using the Vault CLI, use \'vault kv get\' for this operation."],"auth":null}'
-    # rubocop:enable Metrics/LineLength
-  end
 
   it 'errors for malformed uri' do
     expect {
@@ -71,97 +18,80 @@ describe 'vault_lookup::lookup' do
   end
 
   it 'raises a Puppet error when auth fails' do
-    connection = instance_double('Puppet::Network::HTTP::Connection', address: 'vault.doesnotexist')
-    expect(Puppet::Network::HttpPool).to receive(:http_instance).and_return(connection)
-
-    response = Net::HTTPForbidden.new('1.1', 403, auth_failure_data)
-    allow(response).to receive(:body).and_return(auth_failure_data)
-    expect(connection).to receive(:post).with('/v1/auth/cert/login', '').and_return(response)
-
-    expect {
-      function.execute('thepath', 'https://vault.doesnotexist:8200')
-    }.to raise_error(Puppet::Error, %r{Received 403 response code from vault.*invalid certificate or no client certificate supplied})
+    vault_server = MockVault.new
+    vault_server.mount('/v1/auth/cert/login', AuthFailure)
+    vault_server.start_vault do |port|
+      expect {
+        function.execute('thepath', "http://127.0.0.1:#{port}")
+      }.to raise_error(Puppet::Error, %r{Received 403 response code from vault.*invalid certificate or no client certificate supplied})
+    end
   end
 
   it 'raises a Puppet error when data lookup fails' do
-    connection = instance_double('Puppet::Network::HTTP::Connection', address: 'vault.doesnotexist')
-    expect(Puppet::Network::HttpPool).to receive(:http_instance).and_return(connection)
-
-    auth_response = Net::HTTPOK.new('1.1', 200, '')
-    expect(auth_response).to receive(:body).and_return(auth_success_data)
-    expect(connection).to receive(:post).with('/v1/auth/cert/login', '').and_return(auth_response)
-
-    secret_response = Net::HTTPForbidden.new('1.1', 403, permission_denied_data)
-    allow(secret_response).to receive(:body).and_return(permission_denied_data)
-    expect(connection)
-      .to receive(:get)
-      .with('/v1/secret/test', hash_including('X-Vault-Token' => '7dad29d2-40af-038f-cf9c-0aeb616f8d20'))
-      .and_return(secret_response)
-
-    expect {
-      function.execute('secret/test', 'https://vault.doesnotexist:8200')
-    }.to raise_error(Puppet::Error, %r{Received 403 response code from vault at vault.doesnotexist for secret lookup.*permission denied})
+    vault_server = MockVault.new
+    vault_server.mount('/v1/auth/cert/login', AuthSuccess)
+    vault_server.mount('/v1/secret/test', SecretLookupDenied)
+    vault_server.start_vault do |port|
+      expect {
+        function.execute('secret/test', "http://127.0.0.1:#{port}")
+      }.to raise_error(Puppet::Error, %r{Received 403 response code from vault at .* for secret lookup.*permission denied})
+    end
   end
 
   it 'raises a Puppet error when warning present' do
-    connection = instance_double('Puppet::Network::HTTP::Connection', address: 'vault.doesnotexist')
-    expect(Puppet::Network::HttpPool).to receive(:http_instance).and_return(connection)
-
-    auth_response = Net::HTTPOK.new('1.1', 200, '')
-    expect(auth_response).to receive(:body).and_return(auth_success_data)
-    expect(connection).to receive(:post).with('/v1/auth/cert/login', '').and_return(auth_response)
-
-    secret_response = Net::HTTPNotFound.new('1.1', 404, warnings_data)
-    allow(secret_response).to receive(:body).and_return(warnings_data)
-    expect(connection)
-      .to receive(:get)
-      .with('/v1/secret/test', hash_including('X-Vault-Token' => '7dad29d2-40af-038f-cf9c-0aeb616f8d20'))
-      .and_return(secret_response)
-
-    expect {
-      function.execute('secret/test', 'https://vault.doesnotexist:8200')
-    }.to raise_error(Puppet::Error, %r{Received 404 response code from vault at vault.doesnotexist for secret lookup.*Invalid path for a versioned K/V secrets engine})
+    vault_server = MockVault.new
+    vault_server.mount('/v1/auth/cert/login', AuthSuccess)
+    vault_server.mount('/v1/secret/test', SecretLookupWarning)
+    vault_server.start_vault do |port|
+      expect {
+        function.execute('secret/test', "http://127.0.0.1:#{port}")
+      }.to raise_error(Puppet::Error, %r{Received 404 response code from vault at .* for secret lookup.*Invalid path for a versioned K/V secrets engine})
+    end
   end
 
   it 'logs on, requests a secret using a token, and returns the data wrapped in the Sensitive type' do
-    connection = instance_double('Puppet::Network::HTTP::Connection', address: 'vault.doesnotexist')
-    expect(Puppet::Network::HttpPool).to receive(:http_instance).and_return(connection)
+    vault_server = MockVault.new
+    vault_server.mount('/v1/auth/cert/login', AuthSuccess)
+    vault_server.mount('/v1/secret/test', SecretLookupSuccess)
+    vault_server.start_vault do |port|
+      result = function.execute('secret/test', "http://127.0.0.1:#{port}")
+      expect(result).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
+      expect(result.unwrap).to eq('foo' => 'bar')
+    end
+  end
 
-    auth_response = Net::HTTPOK.new('1.1', 200, '')
-    expect(auth_response).to receive(:body).and_return(auth_success_data)
-    expect(connection).to receive(:post).with('/v1/auth/cert/login', '').and_return(auth_response)
+  it 'is successful when providing a cert_role while authenticating' do
+    vault_server = MockVault.new
+    vault_server.mount('/v1/auth/cert/login', AuthSuccessWithRole)
+    vault_server.mount('/v1/secret/test', SecretLookupSuccess)
+    vault_server.start_vault do |port|
+      result = function.execute('secret/test', "http://127.0.0.1:#{port}", nil, 'test-cert-role')
+      expect(result).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
+      expect(result.unwrap).to eq('foo' => 'bar')
+    end
+  end
 
-    secret_response = Net::HTTPOK.new('1.1', 200, '')
-    expect(secret_response).to receive(:body).and_return(secret_success_data)
-    expect(connection)
-      .to receive(:get)
-      .with('/v1/secret/test', hash_including('X-Vault-Token' => '7dad29d2-40af-038f-cf9c-0aeb616f8d20'))
-      .and_return(secret_response)
-
-    result = function.execute('secret/test', 'https://vault.doesnotexist:8200')
-    expect(result).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
-    expect(result.unwrap).to eq('foo' => 'bar')
+  it 'is successful when providing a custom cert path segment without a trailing slash' do
+    custom_auth_segment = 'v1/custom/auth/segment'
+    vault_server = MockVault.new
+    vault_server.mount("/#{custom_auth_segment}/login", AuthSuccess)
+    vault_server.mount('/v1/secret/test', SecretLookupSuccess)
+    vault_server.start_vault do |port|
+      result = function.execute('secret/test', "http://127.0.0.1:#{port}", custom_auth_segment)
+      expect(result).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
+      expect(result.unwrap).to eq('foo' => 'bar')
+    end
   end
 
   it 'logs on, requests a secret using a token, and returns the data wrapped in the Sensitive type from VAULT_ADDR' do
-    stub_const('ENV', ENV.to_hash.merge('VAULT_ADDR' => 'https://vaultenv.doesnotexist:8200'))
-
-    connection = instance_double('Puppet::Network::HTTP::Connection', address: 'vaultenv.doesnotexist:8200')
-    expect(Puppet::Network::HttpPool).to receive(:http_instance).with('vaultenv.doesnotexist', 8200, true).and_return(connection)
-
-    auth_response = Net::HTTPOK.new('1.1', 200, '')
-    expect(auth_response).to receive(:body).and_return(auth_success_data)
-    expect(connection).to receive(:post).with('/v1/auth/cert/login', '').and_return(auth_response)
-
-    secret_response = Net::HTTPOK.new('1.1', 200, '')
-    expect(secret_response).to receive(:body).and_return(secret_success_data)
-    expect(connection)
-      .to receive(:get)
-      .with('/v1/secret/test', hash_including('X-Vault-Token' => '7dad29d2-40af-038f-cf9c-0aeb616f8d20'))
-      .and_return(secret_response)
-
-    result = function.execute('secret/test')
-    expect(result).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
-    expect(result.unwrap).to eq('foo' => 'bar')
+    vault_server = MockVault.new
+    vault_server.mount('/v1/auth/cert/login', AuthSuccess)
+    vault_server.mount('/v1/secret/test', SecretLookupSuccess)
+    vault_server.start_vault do |port|
+      stub_const('ENV', ENV.to_hash.merge('VAULT_ADDR' => "http://127.0.0.1:#{port}"))
+      result = function.execute('secret/test')
+      expect(result).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
+      expect(result.unwrap).to eq('foo' => 'bar')
+    end
   end
 end

--- a/spec/mock_vault_helper.rb
+++ b/spec/mock_vault_helper.rb
@@ -1,0 +1,150 @@
+require 'webrick'
+
+module PuppetVaultLookupHelpers
+  SECRETS_WARNING_DATA = <<~JSON
+    {
+    	"request_id": "0971a3db-f77a-4b0f-224d-35ff3e05d23d",
+    	"lease_id": "",
+    	"renewable": false,
+    	"lease_duration": 0,
+    	"data": null,
+    	"wrap_info": null,
+    	"warnings": ["Invalid path for a versioned K/V secrets engine. See the API docs for the appropriate API endpoints to use. If using the Vault CLI, use \'vault kv get\' for this operation."],
+    	"auth": null
+    }
+  JSON
+                         .freeze
+
+  SECRET_SUCCESS_DATA = <<~JSON
+    {
+    	"request_id": "e394e8ef-78f3-ac85-fbeb-33f060e911d4",
+    	"lease_id": "",
+    	"renewable": false,
+    	"lease_duration": 604800,
+    	"data": {
+    		"foo": "bar"
+    	},
+    	"wrap_info": null,
+    	"warnings": null,
+    	"auth": null
+    }
+    JSON
+                        .freeze
+
+  AUTH_SUCCESS_DATA = <<~JSON
+      {
+        "request_id": "03d11bd4-b994-c432-150f-5703a75641d1",
+        "lease_id": "",
+        "renewable": false,
+        "lease_duration": 0,
+        "data": null,
+        "wrap_info": null,
+        "warnings": null,
+        "auth": {
+          "client_token": "7dad29d2-40af-038f-cf9c-0aeb616f8d20",
+          "accessor": "fd0c3269-9642-25e5-cebe-27a732be53a0",
+          "policies": [
+            "default",
+            "secret_reader"
+          ],
+          "token_policies": [
+            "default",
+            "secret_reader"
+          ],
+          "metadata": {
+            "authority_key_id": "b7:da:18:2f:cc:09:18:5d:d0:c5:24:0a:0a:66:46:ba:0d:f0:ea:4a",
+            "cert_name": "vault.docker",
+            "common_name": "localhost",
+            "serial_number": "5",
+            "subject_key_id": "ea:00:c0:0b:2d:38:01:28:ba:16:1f:08:64:de:0a:7c:8f:b7:43:33"
+          },
+          "lease_duration": 604800,
+          "renewable": true,
+          "entity_id": "e1bc06c5-303e-eec7-bf58-2a74fae2ec3d"
+        }
+      }
+    JSON
+                      .freeze
+
+  # rubocop:disable Style/MethodName
+  class AuthSuccess < WEBrick::HTTPServlet::AbstractServlet
+    def do_POST(_request, response)
+      response.body = AUTH_SUCCESS_DATA
+      response.status = 200
+      response.content_type = 'application/json'
+    end
+  end
+
+  class AuthSuccessWithRole < WEBrick::HTTPServlet::AbstractServlet
+    def do_POST(request, response)
+      if JSON.parse(request.body) == { 'name' => 'test-cert-role' }
+        response.body = AUTH_SUCCESS_DATA
+        response.status = 200
+        response.content_type = 'application/json'
+      else
+        response.status = 403
+      end
+    end
+  end
+
+  class SecretLookupDenied < WEBrick::HTTPServlet::AbstractServlet
+    def do_GET(_request, response)
+      response.body = '{"errors":["permission denied"]}'
+      response.status = 403
+      response.content_type = 'application/json'
+    end
+  end
+
+  class SecretLookupSuccess < WEBrick::HTTPServlet::AbstractServlet
+    def do_GET(_request, response)
+      response.body = SECRET_SUCCESS_DATA
+      response.status = 200
+      response.content_type = 'application/json'
+    end
+  end
+
+  class SecretLookupWarning < WEBrick::HTTPServlet::AbstractServlet
+    def do_GET(_request, response)
+      response.body = SECRETS_WARNING_DATA
+      response.status = 404
+      response.content_type = 'application/json'
+    end
+  end
+
+  class AuthFailure < WEBrick::HTTPServlet::AbstractServlet
+    def do_POST(_request, response)
+      response.body = '{"errors":["invalid certificate or no client certificate supplied"]}'
+      response.status = 403
+      response.content_type = 'application/json'
+    end
+  end
+  # rubocop:enable Style/MethodName
+
+  class MockVault
+    def initialize
+      @https = WEBrick::HTTPServer.new(
+        BindAddress: '127.0.0.1',
+        Port: 0 # webrick will choose the first available port, and set it in the config
+      )
+
+      trap('INT') do
+        @https.shutdown
+      end
+    end
+
+    def mount(*args)
+      @https.mount(*args)
+    end
+
+    def start_vault
+      Thread.new do
+        @https.start
+      end
+      begin
+        yield @https.config[:Port]
+      ensure
+        @https.shutdown
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR changes the puppet http components and switches it to use the newer
http `runtime`. It also refactors the unit tests to stand up webbrick server for
easier to understand unit testing. Finally, it updates the version of vault used
in testing to the current version.