### PR TITLE
Feat: support retrieving secrets from non-puppet signed Vault listener

### DIFF
--- a/lib/puppet/functions/vault_lookup/lookup.rb
+++ b/lib/puppet/functions/vault_lookup/lookup.rb
@@ -60,7 +60,9 @@ Puppet::Functions.create_function(:'vault_lookup::lookup') do
 
   def get_secret(client, uri, token, namespace)
     headers = { 'X-Vault-Token' => token, 'X-Vault-Namespace' => namespace }.delete_if { |_key, value| value.nil? }
-    secret_response = client.get(uri, headers: headers)
+    secret_response = client.get(uri,
+                                 headers: headers,
+                                 options: { include_system_store: true })
     unless secret_response.success?
       message = "Received #{secret_response.code} response code from vault at #{uri} for secret lookup"
       raise Puppet::Error, append_api_errors(message, secret_response)


### PR DESCRIPTION
This is required to support retrieving secrets from vault where the listener certificate is not a puppet cert

This duplicates the options on the client.post for get_auth_token()

Without it the puppet agent 6.28 successfully retrieves a token but cannot connect to Vault to retrieve a secret. it attempts to create a new tls connection with the puppet ssl context which fails.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Add the system ssl store to client.get options in the get_secret function.
-->

#### This Pull Request (PR) fixes the following issues
<!--
n/a
-->
