### PR TITLE
Kv2 support with a specified secret key

### DIFF
--- a/spec/functions/lookup_spec.rb
+++ b/spec/functions/lookup_spec.rb
@@ -65,7 +65,7 @@ describe 'vault_lookup::lookup' do
     vault_server.mount('/v1/auth/cert/login', AuthSuccess)
     vault_server.mount('/v1/kv/test', SecretLookupSuccessKV2)
     vault_server.start_vault do |port|
-      result = function.execute('kv/test', "http://127.0.0.1:#{port}", '', '', '', "bar")
+      result = function.execute('kv/test', "http://127.0.0.1:#{port}", '', '', '', 'bar')
       expect(result).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
       expect(result.unwrap).to eq('baz')
     end

--- a/spec/functions/lookup_spec.rb
+++ b/spec/functions/lookup_spec.rb
@@ -60,6 +60,17 @@ describe 'vault_lookup::lookup' do
     end
   end
 
+  it 'logs on, requests a secret using a token, and returns the data wrapped in the Sensitive type' do
+    vault_server = MockVault.new
+    vault_server.mount('/v1/auth/cert/login', AuthSuccess)
+    vault_server.mount('/v1/kv/test', SecretLookupSuccessKV2)
+    vault_server.start_vault do |port|
+      result = function.execute('kv/test', "http://127.0.0.1:#{port}", nil, nil, nil, "'bar")
+      expect(result).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
+      expect(result.unwrap).to eq('baz')
+    end
+  end
+
   it 'is successful when providing a cert_role while authenticating' do
     vault_server = MockVault.new
     vault_server.mount('/v1/auth/cert/login', AuthSuccessWithRole)

--- a/spec/functions/lookup_spec.rb
+++ b/spec/functions/lookup_spec.rb
@@ -49,7 +49,7 @@ describe 'vault_lookup::lookup' do
     end
   end
 
-  it 'logs on, requests a secret using a token, and returns the data wrapped in the Sensitive type' do
+  it 'logs on, requests a kv1 secret using a token, and returns the data wrapped in the Sensitive type' do
     vault_server = MockVault.new
     vault_server.mount('/v1/auth/cert/login', AuthSuccess)
     vault_server.mount('/v1/kv/test', SecretLookupSuccess)
@@ -60,7 +60,7 @@ describe 'vault_lookup::lookup' do
     end
   end
 
-  it 'logs on, requests a secret using a token, and returns the data wrapped in the Sensitive type' do
+  it 'logs on, requests a kv2 secret using a token, and returns the data wrapped in the Sensitive type' do
     vault_server = MockVault.new
     vault_server.mount('/v1/auth/cert/login', AuthSuccess)
     vault_server.mount('/v1/kv/test', SecretLookupSuccessKV2)

--- a/spec/functions/lookup_spec.rb
+++ b/spec/functions/lookup_spec.rb
@@ -65,7 +65,7 @@ describe 'vault_lookup::lookup' do
     vault_server.mount('/v1/auth/cert/login', AuthSuccess)
     vault_server.mount('/v1/kv/test', SecretLookupSuccessKV2)
     vault_server.start_vault do |port|
-      result = function.execute('kv/test', "http://127.0.0.1:#{port}", '', '', '', "'bar")
+      result = function.execute('kv/test', "http://127.0.0.1:#{port}", '', '', '', "bar")
       expect(result).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
       expect(result.unwrap).to eq('baz')
     end

--- a/spec/functions/lookup_spec.rb
+++ b/spec/functions/lookup_spec.rb
@@ -61,11 +61,12 @@ describe 'vault_lookup::lookup' do
   end
 
   it 'logs on, requests a kv2 secret using a token, and returns the data wrapped in the Sensitive type' do
+    custom_auth_segment = 'v1/custom/auth/segment'
     vault_server = MockVault.new
-    vault_server.mount('/v1/auth/cert/login', AuthSuccess)
+    vault_server.mount("/#{custom_auth_segment}/login", AuthSuccess)
     vault_server.mount('/v1/kv/test', SecretLookupSuccessKV2)
     vault_server.start_vault do |port|
-      result = function.execute('kv/test', "http://127.0.0.1:#{port}", '', '', '', 'bar')
+      result = function.execute('kv/test', "http://127.0.0.1:#{port}", custom_auth_segment, '', '', 'bar')
       expect(result).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
       expect(result.unwrap).to eq('baz')
     end

--- a/spec/functions/lookup_spec.rb
+++ b/spec/functions/lookup_spec.rb
@@ -65,7 +65,7 @@ describe 'vault_lookup::lookup' do
     vault_server.mount('/v1/auth/cert/login', AuthSuccess)
     vault_server.mount('/v1/kv/test', SecretLookupSuccessKV2)
     vault_server.start_vault do |port|
-      result = function.execute('kv/test', "http://127.0.0.1:#{port}", nil, nil, '', "'bar")
+      result = function.execute('kv/test', "http://127.0.0.1:#{port}", '', '', '', "'bar")
       expect(result).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
       expect(result.unwrap).to eq('baz')
     end

--- a/spec/functions/lookup_spec.rb
+++ b/spec/functions/lookup_spec.rb
@@ -65,7 +65,7 @@ describe 'vault_lookup::lookup' do
     vault_server.mount('/v1/auth/cert/login', AuthSuccess)
     vault_server.mount('/v1/kv/test', SecretLookupSuccessKV2)
     vault_server.start_vault do |port|
-      result = function.execute('kv/test', "http://127.0.0.1:#{port}", nil, nil, nil, "'bar")
+      result = function.execute('kv/test', "http://127.0.0.1:#{port}", nil, nil, '', "'bar")
       expect(result).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
       expect(result.unwrap).to eq('baz')
     end

--- a/spec/mock_vault_helper.rb
+++ b/spec/mock_vault_helper.rb
@@ -52,7 +52,7 @@ module PuppetVaultLookupHelpers
       "warnings": null
     }
     JSON
-                        .freeze
+                            .freeze
 
   AUTH_SUCCESS_DATA = <<~JSON
       {

--- a/spec/mock_vault_helper.rb
+++ b/spec/mock_vault_helper.rb
@@ -31,6 +31,29 @@ module PuppetVaultLookupHelpers
     JSON
                         .freeze
 
+  SECRET_SUCCESS_KV2_DATA = <<~JSON
+    {
+      "request_id": "36b0eadc-890b-1da7-b06d-36bda6a9d94d",
+      "lease_id": "",
+      "lease_duration": 0,
+      "renewable": false,
+      "data": {
+        "data": {
+          "bar": "baz"
+        },
+    "metadata": {
+          "created_time": "2022-07-21T12:38:39.082211175Z",
+          "custom_metadata": null,
+          "deletion_time": "",
+          "destroyed": false,
+          "version": 1
+        }
+      },
+      "warnings": null
+    }
+    JSON
+                        .freeze
+
   AUTH_SUCCESS_DATA = <<~JSON
       {
         "request_id": "03d11bd4-b994-c432-150f-5703a75641d1",
@@ -110,6 +133,14 @@ module PuppetVaultLookupHelpers
   class SecretLookupSuccess < WEBrick::HTTPServlet::AbstractServlet
     def do_GET(_request, response)
       response.body = SECRET_SUCCESS_DATA
+      response.status = 200
+      response.content_type = 'application/json'
+    end
+  end
+
+  class SecretLookupSuccessKV2 < WEBrick::HTTPServlet::AbstractServlet
+    def do_GET(_request, response)
+      response.body = SECRET_SUCCESS_KV2_DATA
       response.status = 200
       response.content_type = 'application/json'
     end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Adds support for Vault KV2 format secrets and allows addressing a key within a vault secret

With 0.4.0 a kv2 returns a complete hash including creation version and other metadata. this fails to be converted to a string causing an agent compile error

#### This Pull Request (PR) fixes the following issues
Fixes #21 
Fixes #25 
