### PR TITLE
Fix error: "client certificate must be supplied" #57

### DIFF
--- a/lib/puppet/functions/vault_lookup/lookup.rb
+++ b/lib/puppet/functions/vault_lookup/lookup.rb
@@ -102,7 +102,7 @@ Puppet::Functions.create_function(:'vault_lookup::lookup') do
     response = client.post(login_url,
                            role_data,
                            headers: headers,
-                           options: {  ssl_context: ssl_context })
+                           options: { ssl_context: ssl_context })
     unless response.success?
       message = "Received #{response.code} response code from vault at #{login_url} for authentication"
       raise Puppet::Error, append_api_errors(message, response)


### PR DESCRIPTION



#### Pull Request (PR) description
This fixes https://github.com/voxpupuli/puppet-vault_lookup/issues/57 by including the node's cert/key in the ssl_context while including the system context to allow for certs outside of the puppet CA infrastructure.  These changes were based on similar changes in https://github.com/bastelfreak/puppet-catalog-diff/commit/06c6c835232d3c6ce5e6aabc65d041eb8fb54042.

#### This Pull Request (PR) fixes the following issues
Fixes #57 
