### PR TITLE
Return nil on 404 not found

### DIFF
--- a/lib/puppet/functions/vault_lookup/lookup.rb
+++ b/lib/puppet/functions/vault_lookup/lookup.rb
@@ -10,7 +10,7 @@ Puppet::Functions.create_function(:'vault_lookup::lookup') do
     optional_param 'String', :vault_role_id
     optional_param 'String', :vault_secret_id
     optional_param 'Optional[String]', :vault_approle_path_segment
-    return_type 'Sensitive'
+    return_type 'Optional[Sensitive]'
   end
 
   DEFAULT_CERT_PATH_SEGMENT = 'v1/auth/cert/'.freeze
@@ -89,7 +89,9 @@ Puppet::Functions.create_function(:'vault_lookup::lookup') do
                       token,
                       vault_namespace,
                       vault_key)
-    Puppet::Pops::Types::PSensitiveType::Sensitive.new(data)
+    unless data.nil?
+      Puppet::Pops::Types::PSensitiveType::Sensitive.new(data)
+    end
   end
 
   private
@@ -107,6 +109,8 @@ Puppet::Functions.create_function(:'vault_lookup::lookup') do
     secret_response = client.get(uri,
                                  headers: headers,
                                  options: { include_system_store: true })
+
+    return nil if secret_response.code == 404
     unless secret_response.success?
       message = "Received #{secret_response.code} response code from vault at #{uri} for secret lookup"
       raise Puppet::Error, append_api_errors(message, secret_response)


### PR DESCRIPTION

The current implementation raises an exception if the lookup fails to resolve a result.... this just doesn't make sense for a data lookup, its more that conceivable that most of the time we will look up a value that might not exist.... raising an exception here means there is no way to handle this within Puppet and limits the usability of this function.

Instead of raising an exception, this PR changes the behaviour so that unresolved lookups return nil (Undef) and can therefore be handled within Puppet code.

```
$secret = vault_lookup('secret/data/no_exist')
if $secret {
  $plantext = $secret.unwrap
}
```

Without this patch I fail to see how you can ever look up a value that doesn't exist, since it raises an exception and fails the Puppet run it becomes un-handlable.
