### PR TITLE
Allow for setting lookup options with a hash instead of positional arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ In both cases, the path to the secret is the first positional argument and is re
 
 Positional arguments signature:
 ```
-vault::vault_lookup( <path>, [<vault_url>], [<vault_cert_path_segment>], [<vault_cert_role>], [<vault_namespace>], [<vault_key>], [<vault_auth_method>], [<vault_role_id>], [<vault_secret_id>], [<vault_approle_path_segment>] )
+vault::vault_lookup( <path>, [<vault_addr>], [<cert_path_segment>], [<cert_role>], [<namespace>], [<field>], [<auth_method>], [<role_id>], [<secret_id>], [<approle_path_segment>] )
 ```
 
 Options hash signature:
@@ -183,10 +183,10 @@ $data_2a = vault::vault_lookup('secret/db/blah', 'https://vault.corp.net:8200', 
 # Options hash
 $data_1b = vault::vault_lookup('secret/db/password', { 'vault_addr' => 'https://vault.corp.net:8200' })
 $data_2b = vault::vault_lookup('secret/db/blah', {
-  'vault_addr'        => 'https://vault.corp.net:8200',
-  'vault_auth_method' => 'approle',
-  'vault_role_id'     => 'team_a',
-  'vault_secret_id'   => 'abcd1234!@#',
+  'vault_addr'  => 'https://vault.corp.net:8200',
+  'auth_method' => 'approle',
+  'role_id'     => 'team_a',
+  'secret_id'   => 'abcd1234!@#',
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -154,3 +154,39 @@ node default {
   }
 }
 ```
+
+### Configuring the Vault lookup
+
+The lookup done by `vault::vault_lookup()` can be configured in two ways: positional arguments or with a hash of options.
+
+In both cases, the path to the secret is the first positional argument and is required. All other arguments are optional.
+
+Positional arguments signature:
+```
+vault::vault_lookup( <path>, [<vault_url>], [<vault_cert_path_segment>], [<vault_cert_role>], [<vault_namespace>], [<vault_key>], [<vault_auth_method>], [<vault_role_id>], [<vault_secret_id>], [<vault_approle_path_segment>] )
+```
+
+Options hash signature:
+```
+vault::vault_lookup( <path>, [<options_hash>] )
+```
+
+Arguments in `[square brackets]` are optional.
+
+
+Here are some examples of each method:
+```
+# Positional arguments
+$data_1a = vault::vault_lookup('secret/db/password', 'https://vault.corp.net:8200')
+$data_2a = vault::vault_lookup('secret/db/blah', 'https://vault.corp.net:8200', undef, undef, undef, undef, 'approle', 'team_a', 'abcd1234!@#')
+
+# Options hash
+$data_1b = vault::vault_lookup('secret/db/password', { 'vault_addr' => 'https://vault.corp.net:8200' })
+$data_2b = vault::vault_lookup('secret/db/blah', {
+  'vault_addr'        => 'https://vault.corp.net:8200',
+  'vault_auth_method' => 'approle',
+  'vault_role_id'     => 'team_a',
+  'vault_secret_id'   => 'abcd1234!@#',
+})
+```
+

--- a/README.md
+++ b/README.md
@@ -43,10 +43,11 @@ data.
 
 ### To set up Vault to use the Puppet Server CA cert:
 
-The `vault_lookup` function can use the Puppet agent's certificates in order to
-authenticate to the Vault server; this means that before any agents contact a
-Vault server, you must configure the Vault server with the Puppet Server's CA
-certificate, and Vault must be part of the same certificate infrastructure.
+The `vault::vault_lookup()` function can use the Puppet agent's certificates in
+order to authenticate to the Vault server; this means that before any agents
+contact a Vault server, you must configure the Vault server with the Puppet
+Server's CA certificate, and Vault must be part of the same certificate
+infrastructure.
 
 1. Set up Vault using Puppet certs (if not already set up this way)
   If the Vault host has a Puppet agent on it then you can just use the existing
@@ -63,8 +64,9 @@ puppetserver ca generate --certname my-vault.my-domain.me
 
 2. Enable cert auth for Vault
   Hashicorp’s Vault supports a variety of auth methods that are listed in their
-  documentation; the auth method required for usage with the vault_lookup
-  function is named cert, and can be turned on with the Vault CLI:
+  documentation; the auth method required for usage with the
+  `vault:vault_lookup()` function is named cert, and can be turned on with the
+  Vault CLI:
 
 ```
 $ vault auth enable cert
@@ -86,7 +88,7 @@ certificate will be able to authenticate with Vault.
 
 ### To use AppRole Authentication
 
-`vault_lookup` can also use AppRole authentication to authenticate against Vault with a valid `role_id` and `secret_id`.  See [The Approle Vault Documentation](https://www.vaultproject.io/docs/auth/approle) for detailed explanations of creating and obtaining the security credentials.   You will need the Role ID (non sensitive) and the Secret ID (sensitive!).  The Secret ID can be provided as an argument to the `vault_lookup` function but it is recommended to pass this as an environment variable and not bake this into code.
+`vault:vault_lookup()` can also use AppRole authentication to authenticate against Vault with a valid `role_id` and `secret_id`.  See [The Approle Vault Documentation](https://www.vaultproject.io/docs/auth/approle) for detailed explanations of creating and obtaining the security credentials.   You will need the Role ID (non sensitive) and the Secret ID (sensitive!).  The Secret ID can be provided as an argument to the `vault:vault_lookup()` function but it is recommended to pass this as an environment variable and not bake this into code.
 
 Example:
 ```
@@ -120,8 +122,8 @@ export VAULT_SECRET_ID=YYYYY-YYYY-YYY-YY-YYYYYYYYYYY
 Install this module as you would in any other; the necessary code will
 be distributed to Puppet agents via pluginsync.
 
-In your manifests, call the `vault_lookup::lookup` function using the Deferred
-type. For example:
+In your manifests, call the `vault_lookup::lookup()` function using the
+Deferred type. For example:
 
 ```puppet
 $d = Deferred('vault_lookup::lookup', ["secret/test", 'https://vault.hostname:8200'])

--- a/lib/puppet/functions/vault_lookup/lookup.rb
+++ b/lib/puppet/functions/vault_lookup/lookup.rb
@@ -13,9 +13,44 @@ Puppet::Functions.create_function(:'vault_lookup::lookup') do
     return_type 'Sensitive'
   end
 
+  dispatch :lookup_opts_hash do
+    # Allows for passing a hash of options to the vault::vault_lookup() function.
+    #
+    # @example
+    #  $foo = vault::lookup('secret/some/path/foo',
+    #    {'vault_url' => 'https://vault.corp.net:8200', 'auth_method' => 'cert'}
+    #  )
+    #
+    param 'String[1]', :path
+    param 'Hash[String[1], Data]', :options
+    return_type 'Sensitive'
+  end
+
+  # Lookup with a path and an options hash.
+  def lookup_opts_hash(path, options = {})
+    # NOTE: The order of these options MUST be the same as the lookup()
+    # function's signature. If new parameters are added to lookup(), or if the
+    # order of existing parameters change, those changes must also be made
+    # here.
+    lookup(path,
+           options['vault_url'],
+           options['vault_cert_path_segment'],
+           options['vault_cert_role'],
+           options['vault_namespace'],
+           options['vault_key'],
+           options['vault_auth_method'],
+           options['vault_role_id'],
+           options['vault_secret_id'],
+           options['vault_approle_path_segment'])
+  end
+
   DEFAULT_CERT_PATH_SEGMENT = 'v1/auth/cert/'.freeze
   DEFAULT_APPROLE_PATH_SEGMENT = 'v1/auth/approle/'.freeze
 
+  # Lookup with a path and positional arguments.
+  # NOTE: If new parameters are added, or if the order of existing parameters
+  # change, those changes must also be made to the lookup() call in
+  # lookup_opts_hash().
   def lookup(path,
              vault_url = nil,
              vault_cert_path_segment = nil,

--- a/lib/puppet/functions/vault_lookup/lookup.rb
+++ b/lib/puppet/functions/vault_lookup/lookup.rb
@@ -1,15 +1,15 @@
 Puppet::Functions.create_function(:'vault_lookup::lookup') do
   dispatch :lookup do
     param 'String', :path
-    optional_param 'String', :vault_url
-    optional_param 'Optional[String]', :vault_cert_path_segment
-    optional_param 'String', :vault_cert_role
-    optional_param 'String', :vault_namespace
-    optional_param 'String', :vault_key
-    optional_param 'Enum["cert", "approle"]', :vault_auth_method
-    optional_param 'String', :vault_role_id
-    optional_param 'String', :vault_secret_id
-    optional_param 'Optional[String]', :vault_approle_path_segment
+    optional_param 'String', :vault_addr
+    optional_param 'Optional[String]', :cert_path_segment
+    optional_param 'String', :cert_role
+    optional_param 'String', :namespace
+    optional_param 'String', :field
+    optional_param 'Enum["cert", "approle"]', :auth_method
+    optional_param 'String', :role_id
+    optional_param 'String', :secret_id
+    optional_param 'Optional[String]', :approle_path_segment
     return_type 'Sensitive'
   end
 
@@ -18,7 +18,7 @@ Puppet::Functions.create_function(:'vault_lookup::lookup') do
     #
     # @example
     #  $foo = vault::lookup('secret/some/path/foo',
-    #    {'vault_url' => 'https://vault.corp.net:8200', 'auth_method' => 'cert'}
+    #    {'vault_addr' => 'https://vault.corp.net:8200', 'auth_method' => 'cert'}
     #  )
     #
     param 'String[1]', :path
@@ -33,15 +33,15 @@ Puppet::Functions.create_function(:'vault_lookup::lookup') do
     # order of existing parameters change, those changes must also be made
     # here.
     lookup(path,
-           options['vault_url'],
-           options['vault_cert_path_segment'],
-           options['vault_cert_role'],
-           options['vault_namespace'],
-           options['vault_key'],
-           options['vault_auth_method'],
-           options['vault_role_id'],
-           options['vault_secret_id'],
-           options['vault_approle_path_segment'])
+           options['vault_addr'],
+           options['cert_path_segment'],
+           options['cert_role'],
+           options['namespace'],
+           options['field'],
+           options['auth_method'],
+           options['role_id'],
+           options['secret_id'],
+           options['approle_path_segment'])
   end
 
   DEFAULT_CERT_PATH_SEGMENT = 'v1/auth/cert/'.freeze
@@ -52,86 +52,86 @@ Puppet::Functions.create_function(:'vault_lookup::lookup') do
   # change, those changes must also be made to the lookup() call in
   # lookup_opts_hash().
   def lookup(path,
-             vault_url = nil,
-             vault_cert_path_segment = nil,
-             vault_cert_role = nil,
-             vault_namespace = nil,
-             vault_key = nil,
-             vault_auth_method = nil,
-             vault_role_id = nil,
-             vault_secret_id = nil,
-             vault_approle_path_segment = nil)
+             vault_addr = nil,
+             cert_path_segment = nil,
+             cert_role = nil,
+             namespace = nil,
+             field = nil,
+             auth_method = nil,
+             role_id = nil,
+             secret_id = nil,
+             approle_path_segment = nil)
 
-    if vault_auth_method.nil?
-      vault_auth_method = ENV['VAULT_AUTH_METHOD'] || 'cert'
+    if auth_method.nil?
+      auth_method = ENV['VAULT_AUTH_METHOD'] || 'cert'
     end
 
-    if vault_url.nil?
+    if vault_addr.nil?
       Puppet.debug 'No Vault address was set on function, defaulting to value from VAULT_ADDR env value'
-      vault_url = ENV['VAULT_ADDR']
-      raise Puppet::Error, 'No vault_url given and VAULT_ADDR env variable not set' if vault_url.nil?
+      vault_addr = ENV['VAULT_ADDR']
+      raise Puppet::Error, 'No vault_addr given and VAULT_ADDR env variable not set' if vault_addr.nil?
     end
-    if vault_namespace.nil?
+    if namespace.nil?
       Puppet.debug 'No Vault namespace was set on function, defaulting to value from VAULT_NAMESPACE env value'
-      vault_namespace = ENV['VAULT_NAMESPACE']
+      namespace = ENV['VAULT_NAMESPACE']
     end
 
-    if vault_role_id.nil?
-      vault_role_id = ENV['VAULT_ROLE_ID']
+    if role_id.nil?
+      role_id = ENV['VAULT_ROLE_ID']
     end
 
-    if vault_secret_id.nil?
-      vault_secret_id = ENV['VAULT_SECRET_ID']
+    if secret_id.nil?
+      secret_id = ENV['VAULT_SECRET_ID']
     end
 
-    if vault_cert_path_segment.nil?
-      vault_cert_path_segment = DEFAULT_CERT_PATH_SEGMENT
+    if cert_path_segment.nil?
+      cert_path_segment = DEFAULT_CERT_PATH_SEGMENT
     end
 
-    if vault_approle_path_segment.nil?
-      vault_approle_path_segment = DEFAULT_APPROLE_PATH_SEGMENT
+    if approle_path_segment.nil?
+      approle_path_segment = DEFAULT_APPROLE_PATH_SEGMENT
     end
-    vault_base_uri = URI(vault_url)
-    # URI is used here to parse the vault_url into a host string
+    vault_base_uri = URI(vault_addr)
+    # URI is used here to parse the vault_addr into a host string
     # and port; it's possible to generate a URI::Generic when a scheme
     # is not defined, so double check here to make sure at least
     # host is defined.
-    raise Puppet::Error, "Unable to parse a hostname from #{vault_url}" unless vault_base_uri.hostname
+    raise Puppet::Error, "Unable to parse a hostname from #{vault_addr}" unless vault_base_uri.hostname
 
     client = Puppet.runtime[:http]
 
-    case vault_auth_method
+    case auth_method
     when 'cert'
       token = get_cert_auth_token(client,
                                   vault_base_uri,
-                                  vault_cert_path_segment,
-                                  vault_cert_role,
-                                  vault_namespace)
+                                  cert_path_segment,
+                                  cert_role,
+                                  namespace)
     when 'approle'
-      raise Puppet::Error, 'vault_role_id and VAULT_ROLE_ID are both nil' if vault_role_id.nil?
-      raise Puppet::Error, 'vault_secret_id and VAULT_SECRET_ID are both nil' if vault_secret_id.nil?
+      raise Puppet::Error, 'role_id and VAULT_ROLE_ID are both nil' if vault_role_id.nil?
+      raise Puppet::Error, 'secret_id and VAULT_SECRET_ID are both nil' if vault_secret_id.nil?
       token = get_approle_auth_token(client,
                                      vault_base_uri,
-                                     vault_approle_path_segment,
-                                     vault_role_id,
-                                     vault_secret_id,
-                                     vault_namespace)
+                                     approle_path_segment,
+                                     role_id,
+                                     secret_id,
+                                     namespace)
     end
 
     secret_uri = vault_base_uri + "/v1/#{path.delete_prefix('/')}"
     data = get_secret(client,
                       secret_uri,
                       token,
-                      vault_namespace,
-                      vault_key)
+                      namespace,
+                      field)
     Puppet::Pops::Types::PSensitiveType::Sensitive.new(data)
   end
 
   private
 
-  def auth_login_body(vault_cert_role)
-    if vault_cert_role
-      { name: vault_cert_role }.to_json
+  def auth_login_body(cert_role)
+    if cert_role
+      { name: cert_role }.to_json
     else
       ''
     end
@@ -157,29 +157,29 @@ Puppet::Functions.create_function(:'vault_lookup::lookup') do
     end
   end
 
-  def get_cert_auth_token(client, vault_url, vault_cert_path_segment, vault_cert_role, vault_namespace)
-    role_data = auth_login_body(vault_cert_role)
-    segment = if vault_cert_path_segment.end_with?('/')
-                vault_cert_path_segment
+  def get_cert_auth_token(client, vault_addr, cert_path_segment, cert_role, namespace)
+    role_data = auth_login_body(cert_role)
+    segment = if cert_path_segment.end_with?('/')
+                cert_path_segment
               else
-                vault_cert_path_segment + '/'
+                cert_path_segment + '/'
               end
-    login_url = vault_url + segment + 'login'
-    get_token(client, login_url, role_data, vault_namespace)
+    login_url = vault_addr + segment + 'login'
+    get_token(client, login_url, role_data, namespace)
   end
 
-  def get_approle_auth_token(client, vault_url, path_segment, vault_role_id, vault_secret_id, vault_namespace)
+  def get_approle_auth_token(client, vault_addr, path_segment, role_id, secret_id, namespace)
     vault_request_data = {
-      role_id: vault_role_id,
-      secret_id: vault_secret_id
+      role_id: role_id,
+      secret_id: secret_id
     }.to_json
 
-    login_url = vault_url + path_segment + 'login'
-    get_token(client, login_url, vault_request_data, vault_namespace)
+    login_url = vault_addr + path_segment + 'login'
+    get_token(client, login_url, vault_request_data, namespace)
   end
 
-  def get_token(client, login_url, request_data, vault_namespace)
-    headers = { 'Content-Type' => 'application/json', 'X-Vault-Namespace' => vault_namespace }.delete_if { |_key, value| value.nil? }
+  def get_token(client, login_url, request_data, namespace)
+    headers = { 'Content-Type' => 'application/json', 'X-Vault-Namespace' => namespace }.delete_if { |_key, value| value.nil? }
     response = client.post(login_url,
                            request_data,
                            headers: headers,

--- a/spec/functions/lookup_spec.rb
+++ b/spec/functions/lookup_spec.rb
@@ -11,18 +11,18 @@ describe 'vault_lookup::lookup' do
     }.to raise_error(Puppet::Error, %r{Unable to parse a hostname})
 
     expect {
-      function.execute('/v1/whatever', 'vault_url' => 'vault.docker')
+      function.execute('/v1/whatever', 'vault_addr' => 'vault.docker')
     }.to raise_error(Puppet::Error, %r{Unable to parse a hostname})
   end
 
-  it 'errors when no vault_url set and no VAULT_ADDR environment variable' do
+  it 'errors when no vault_addr set and no VAULT_ADDR environment variable' do
     expect {
       function.execute('/v1/whatever')
-    }.to raise_error(Puppet::Error, %r{No vault_url given and VAULT_ADDR env variable not set})
+    }.to raise_error(Puppet::Error, %r{No vault_addr given and VAULT_ADDR env variable not set})
 
     expect {
       function.execute('/v1/whatever', {})
-    }.to raise_error(Puppet::Error, %r{No vault_url given and VAULT_ADDR env variable not set})
+    }.to raise_error(Puppet::Error, %r{No vault_addr given and VAULT_ADDR env variable not set})
   end
 
   it 'raises a Puppet error when auth fails' do
@@ -34,7 +34,7 @@ describe 'vault_lookup::lookup' do
       }.to raise_error(Puppet::Error, %r{Received 403 response code from vault.*invalid certificate or no client certificate supplied})
 
       expect {
-        function.execute('thepath', 'vault_url' => "http://127.0.0.1:#{port}")
+        function.execute('thepath', 'vault_addr' => "http://127.0.0.1:#{port}")
       }.to raise_error(Puppet::Error, %r{Received 403 response code from vault.*invalid certificate or no client certificate supplied})
     end
   end
@@ -49,7 +49,7 @@ describe 'vault_lookup::lookup' do
       }.to raise_error(Puppet::Error, %r{Received 403 response code from vault at .* for secret lookup.*permission denied})
 
       expect {
-        function.execute('kv/test', 'vault_url' => "http://127.0.0.1:#{port}")
+        function.execute('kv/test', 'vault_addr' => "http://127.0.0.1:#{port}")
       }.to raise_error(Puppet::Error, %r{Received 403 response code from vault at .* for secret lookup.*permission denied})
     end
   end
@@ -64,7 +64,7 @@ describe 'vault_lookup::lookup' do
       }.to raise_error(Puppet::Error, %r{Received 404 response code from vault at .* for secret lookup.*Invalid path for a versioned K/V secrets engine})
 
       expect {
-        function.execute('kv/test', 'vault_url' => "http://127.0.0.1:#{port}")
+        function.execute('kv/test', 'vault_addr' => "http://127.0.0.1:#{port}")
       }.to raise_error(Puppet::Error, %r{Received 404 response code from vault at .* for secret lookup.*Invalid path for a versioned K/V secrets engine})
     end
   end
@@ -78,7 +78,7 @@ describe 'vault_lookup::lookup' do
       expect(result).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
       expect(result.unwrap).to eq('foo' => 'bar')
 
-      result_opts = function.execute('kv/test', 'vault_url' => "http://127.0.0.1:#{port}")
+      result_opts = function.execute('kv/test', 'vault_addr' => "http://127.0.0.1:#{port}")
       expect(result_opts).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
       expect(result_opts.unwrap).to eq('foo' => 'bar')
     end
@@ -94,7 +94,7 @@ describe 'vault_lookup::lookup' do
       expect(result).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
       expect(result.unwrap).to eq('baz')
 
-      result_opts = function.execute('kv/test', 'vault_url' => "http://127.0.0.1:#{port}", 'vault_cert_path_segment' => custom_auth_segment, 'vault_key' => 'bar')
+      result_opts = function.execute('kv/test', 'vault_addr' => "http://127.0.0.1:#{port}", 'cert_path_segment' => custom_auth_segment, 'field' => 'bar')
       expect(result_opts).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
       expect(result_opts.unwrap).to eq('baz')
     end
@@ -110,8 +110,8 @@ describe 'vault_lookup::lookup' do
       expect(result.unwrap).to eq('foo' => 'bar')
 
       opts = {
-        'vault_url' => "http://127.0.0.1:#{port}",
-        'vault_cert_role' => 'test-cert-role'
+        'vault_addr' => "http://127.0.0.1:#{port}",
+        'cert_role' => 'test-cert-role'
       }
       result_opts = function.execute('kv/test', opts)
       expect(result_opts).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
@@ -129,7 +129,7 @@ describe 'vault_lookup::lookup' do
       expect(result).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
       expect(result.unwrap).to eq('foo' => 'bar')
 
-      result_opts = function.execute('kv/test', 'vault_url' => "http://127.0.0.1:#{port}", 'vault_cert_path_segment' => custom_auth_segment)
+      result_opts = function.execute('kv/test', 'vault_addr' => "http://127.0.0.1:#{port}", 'cert_path_segment' => custom_auth_segment)
       expect(result_opts).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
       expect(result_opts.unwrap).to eq('foo' => 'bar')
     end

--- a/spec/functions/lookup_spec.rb
+++ b/spec/functions/lookup_spec.rb
@@ -9,11 +9,19 @@ describe 'vault_lookup::lookup' do
     expect {
       function.execute('/v1/whatever', 'vault.docker')
     }.to raise_error(Puppet::Error, %r{Unable to parse a hostname})
+
+    expect {
+      function.execute('/v1/whatever', 'vault_url' => 'vault.docker')
+    }.to raise_error(Puppet::Error, %r{Unable to parse a hostname})
   end
 
   it 'errors when no vault_url set and no VAULT_ADDR environment variable' do
     expect {
       function.execute('/v1/whatever')
+    }.to raise_error(Puppet::Error, %r{No vault_url given and VAULT_ADDR env variable not set})
+
+    expect {
+      function.execute('/v1/whatever', {})
     }.to raise_error(Puppet::Error, %r{No vault_url given and VAULT_ADDR env variable not set})
   end
 
@@ -23,6 +31,10 @@ describe 'vault_lookup::lookup' do
     vault_server.start_vault do |port|
       expect {
         function.execute('thepath', "http://127.0.0.1:#{port}")
+      }.to raise_error(Puppet::Error, %r{Received 403 response code from vault.*invalid certificate or no client certificate supplied})
+
+      expect {
+        function.execute('thepath', 'vault_url' => "http://127.0.0.1:#{port}")
       }.to raise_error(Puppet::Error, %r{Received 403 response code from vault.*invalid certificate or no client certificate supplied})
     end
   end
@@ -35,6 +47,10 @@ describe 'vault_lookup::lookup' do
       expect {
         function.execute('kv/test', "http://127.0.0.1:#{port}")
       }.to raise_error(Puppet::Error, %r{Received 403 response code from vault at .* for secret lookup.*permission denied})
+
+      expect {
+        function.execute('kv/test', 'vault_url' => "http://127.0.0.1:#{port}")
+      }.to raise_error(Puppet::Error, %r{Received 403 response code from vault at .* for secret lookup.*permission denied})
     end
   end
 
@@ -45,6 +61,10 @@ describe 'vault_lookup::lookup' do
     vault_server.start_vault do |port|
       expect {
         function.execute('kv/test', "http://127.0.0.1:#{port}")
+      }.to raise_error(Puppet::Error, %r{Received 404 response code from vault at .* for secret lookup.*Invalid path for a versioned K/V secrets engine})
+
+      expect {
+        function.execute('kv/test', 'vault_url' => "http://127.0.0.1:#{port}")
       }.to raise_error(Puppet::Error, %r{Received 404 response code from vault at .* for secret lookup.*Invalid path for a versioned K/V secrets engine})
     end
   end
@@ -57,6 +77,10 @@ describe 'vault_lookup::lookup' do
       result = function.execute('kv/test', "http://127.0.0.1:#{port}")
       expect(result).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
       expect(result.unwrap).to eq('foo' => 'bar')
+
+      result_opts = function.execute('kv/test', 'vault_url' => "http://127.0.0.1:#{port}")
+      expect(result_opts).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
+      expect(result_opts.unwrap).to eq('foo' => 'bar')
     end
   end
 
@@ -69,6 +93,10 @@ describe 'vault_lookup::lookup' do
       result = function.execute('kv/test', "http://127.0.0.1:#{port}", custom_auth_segment, '', '', 'bar')
       expect(result).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
       expect(result.unwrap).to eq('baz')
+
+      result_opts = function.execute('kv/test', 'vault_url' => "http://127.0.0.1:#{port}", 'vault_cert_path_segment' => custom_auth_segment, 'vault_key' => 'bar')
+      expect(result_opts).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
+      expect(result_opts.unwrap).to eq('baz')
     end
   end
 
@@ -80,6 +108,14 @@ describe 'vault_lookup::lookup' do
       result = function.execute('kv/test', "http://127.0.0.1:#{port}", nil, 'test-cert-role')
       expect(result).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
       expect(result.unwrap).to eq('foo' => 'bar')
+
+      opts = {
+        'vault_url' => "http://127.0.0.1:#{port}",
+        'vault_cert_role' => 'test-cert-role'
+      }
+      result_opts = function.execute('kv/test', opts)
+      expect(result_opts).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
+      expect(result_opts.unwrap).to eq('foo' => 'bar')
     end
   end
 
@@ -92,6 +128,10 @@ describe 'vault_lookup::lookup' do
       result = function.execute('kv/test', "http://127.0.0.1:#{port}", custom_auth_segment)
       expect(result).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
       expect(result.unwrap).to eq('foo' => 'bar')
+
+      result_opts = function.execute('kv/test', 'vault_url' => "http://127.0.0.1:#{port}", 'vault_cert_path_segment' => custom_auth_segment)
+      expect(result_opts).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
+      expect(result_opts.unwrap).to eq('foo' => 'bar')
     end
   end
 


### PR DESCRIPTION
## Before this change

Prior to this, options for the Vault lookup had to be set via positional
arguments to the `vault::vault_lookup()` function. That made it rather clunky
to do simple changes like switch which auth method you wanted to use or specify
a specific field to extract from the lookup.

For example, before this change, using positional arguments meant doing
something like this:
```
# The explicit undef's are neccessary and clunky here.
$data_auth_method_approle = Deferred('vault_lookup::lookup', ['secret/test', undef, undef, undef, undef, 'approle', 'team_a', 'abcd1234!@#'])

$data_specific_field = Deferred('vault_lookup::lookup', ['secret/test', undef, undef, undef, undef, 'message'])
```

## After this change

After this, all options other than the path can be specified in a hash as named
parameters. The benefit of using a hash for options is that it's much simpler
and clearer to configure the lookup.

Now, lookups can use an options hash which clarifies the intent of each lookup:
```
$data_auth_method_approle = Deferred('vault_lookup::lookup', ['secret/test', {
  'auth_method' => 'approle',
  'role_id'     => 'team_a',
  'secret_id'   => 'abcd1234!@#',
}])

$data_specific_field = Deferred('vault_lookup::lookup', ['secret/test', {'field' => 'message'}])
```

Note that as part of this change, I updated the name of the internal function's
parameters to shorten and simplify them. For example, the internal function's
parameter called `vault_url` was changed to `vault_addr` to match standard
Vault naming convention, and `vault_namespace` was changed to just `namespace`
as that makes it simpler to use the options hash since there's fewer letters to
type.
