### PR TITLE
Cache the result of a lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,3 +190,74 @@ $data_2b = vault::vault_lookup('secret/db/blah', {
 })
 ```
 
+### A note about caching
+
+The `vault_lookup::lookup()` function caches the result of a lookup and will
+use that cached result for the life of the catalog application (when using
+`Deferred`) or catalog compilation (when not using `Deferred`).
+
+Looked up values are cached based on a combination of their:
+* Path in the Vault URI
+* Vault Address
+* Namespace
+
+This means that you can call `vault_lookup::lookup()` multiple times for the
+same piece of data or refer to the same `Deferred` value multiple times and
+there will only be a single fetch from Vault. This helps to reduce the amount
+of back-and-forth network traffic to your Vault cluster.
+
+For example, in the code below, due to caching, the `secret/db/password` value
+is only looked up once even though the function is called twice:
+
+```puppet
+# Wrap the function in Deferred, and save it to a variable.
+#
+# Since the path, vault_addr, and namespace don't change, only one Vault lookup
+# will be made regardless of how many times the $db_password variable is used.
+#
+$db_password = Deferred('vault_lookup::lookup', [
+  'secret/db/password',
+  {'vault_addr' => 'https://vault.corp.net:8200'},
+])
+
+# Call the deferred function once.
+file { '/etc/db.conf':
+  ensure  => file,
+  content => $db_password,
+}
+
+# Call the deferred function twice.
+notify { 'show the DB password':
+  message => $db_password,
+}
+```
+
+But if the path, the Vault address, or the namespace change, a new lookup to
+Vault will happen. For example, in the code below, even though the path is the
+same in both of these lookups (`secret/db/password`), the namespace is
+different, so a separate lookup will be made rather than the cached value from
+the first lookup of `secret/db/password` being used.
+
+```puppet
+# Fetch a value from Vault without using a namespace.
+$db_password = Deferred('vault_lookup::lookup', [
+  'secret/db/password',
+  {'vault_addr' => 'https://vault.corp.net:8200'},
+])
+
+# Fetch a value from Vault in the 'dev' namespace.
+$db_password_namespaced = Deferred('vault_lookup::lookup', [
+  'secret/db/password',
+  {'vault_addr' => 'https://vault.corp.net:8200', 'namespace' => 'dev'},
+])
+
+file { '/etc/db.conf':
+  ensure  => file,
+  content => $db_password,
+}
+
+notify { 'show the dev namespace DB password':
+  message => $db_password_namespaced,
+}
+```
+


### PR DESCRIPTION
### Description

This caches the result of a Vault lookup based on the `path`, `vault_addr`, and `namespace` used for the lookup.
All subsequent lookups of the same secret will be returned from Puppet's built in cache rather than being fetched from Vault again.

The caching implementation uses the `cache_param` feature of the 4.x Function API added here: https://tickets.puppetlabs.com/browse/PUP-8676

An example of why this cache is needed can be seen with this bit of Puppet code:
```puppet
$data = Deferred('vault_lookup::lookup', ['foo', 'https://vault.corp.net:8200'])

notify { 'message1':
  message => $data,
}

notify { 'message2':
  message => $data,
}
```

Before this change, the lookup for `foo` would be done twice per catalog application due to the two `notify` resources evaluating the Deferred type.

After this change, the lookup for `foo` would only be done once per catalog application.