### PR TITLE
(WIP) Add new auth methods: agent, agent_sink

### DIFF
--- a/spec/mock_vault_helper.rb
+++ b/spec/mock_vault_helper.rb
@@ -3,30 +3,30 @@ require 'webrick'
 module PuppetVaultLookupHelpers
   SECRETS_WARNING_DATA = <<~JSON
     {
-    	"request_id": "0971a3db-f77a-4b0f-224d-35ff3e05d23d",
-    	"lease_id": "",
-    	"renewable": false,
-    	"lease_duration": 0,
-    	"data": null,
-    	"wrap_info": null,
-    	"warnings": ["Invalid path for a versioned K/V secrets engine. See the API docs for the appropriate API endpoints to use. If using the Vault CLI, use \'vault kv get\' for this operation."],
-    	"auth": null
+      "request_id": "0971a3db-f77a-4b0f-224d-35ff3e05d23d",
+      "lease_id": "",
+      "renewable": false,
+      "lease_duration": 0,
+      "data": null,
+      "wrap_info": null,
+      "warnings": ["Invalid path for a versioned K/V secrets engine. See the API docs for the appropriate API endpoints to use. If using the Vault CLI, use \'vault kv get\' for this operation."],
+      "auth": null
     }
   JSON
                          .freeze
 
   SECRET_SUCCESS_DATA = <<~JSON
     {
-    	"request_id": "e394e8ef-78f3-ac85-fbeb-33f060e911d4",
-    	"lease_id": "",
-    	"renewable": false,
-    	"lease_duration": 604800,
-    	"data": {
-    		"foo": "bar"
-    	},
-    	"wrap_info": null,
-    	"warnings": null,
-    	"auth": null
+      "request_id": "e394e8ef-78f3-ac85-fbeb-33f060e911d4",
+      "lease_id": "",
+      "renewable": false,
+      "lease_duration": 604800,
+      "data": {
+        "foo": "bar"
+      },
+      "wrap_info": null,
+      "warnings": null,
+      "auth": null
     }
     JSON
                         .freeze


### PR DESCRIPTION
#### Description
This adds support for two new authentication methods when doing the Vault lookup.

##### `agent`:

This allows the lookup function to use a local Vault Agent proxy for access to Vault, rather than talking directly to a Vault server.

When using `auth_method => agent`, it is expected that the Vault agent is acting a local caching proxy for Vault. For example, with this agent config:

```hcl                                                       
vault {                                                      
  address = "https://vault.corp.net:8200"                    
}                                                            
                                                             
listener "tcp" {                                             
  address = "127.0.0.1:8100"                                 
  tls_disable = true                                         
}                                                            
                                                             
auto_auth {                                                  
  # Some type of auto_auth configuration from:               
  # https://developer.hashicorp.com/vault/docs/agent/autoauth
}                                                            
                                                             
cache {                                                      
  use_auto_auth_token = true                                 
}                                                            
```                                                          

##### `agent_sink`:

This auth method allows you to use a Vault Agent's sink file that contains a token, rather than passing the token to the lookup function.

An example Vault agent config that would be used with `agent_sink` is this:

```hcl 
vault {                                                                   
  address = "https://vault.corp.net:8200"                                 
}                                                                         
                                                                          
# The listener is optional here, but could be used for the 'vault_addr' in
# the vault_lookup::lookup() Puppet function.                             
listener "tcp" {                                                          
  address     = "127.0.0.1:8100"                                          
  tls_disable = true                                                      
}                                                                         
                                                                          
auto_auth {                                                               
  # Some type of auto_auth method from:                                   
  # https://developer.hashicorp.com/vault/docs/agent/autoauth/methods     
  method { }                                                              
                                                                          
  sink {                                                                  
    type = "file"                                                         
    config = {                                                            
      path = "/path/to/vault-token                                        
    }                                                                     
  }                                                                       
}                                                                         
```

#### Issues Fixed
Fixes #7
Fixes #24

#### TODO

* [x] spec tests
* [x] Clarify that only unencrypted, non response-wrapped tokens are supported with `agent_sink` mode
* [x] Fix readme typos I introduced last time: `vault::vault_lookup()` -> `vault_lookup::lookup()`