### PR TITLE
fix: following same logic of returning secret body when not specifying a vault key

### DIFF
--- a/lib/puppet/functions/vault_lookup/lookup.rb
+++ b/lib/puppet/functions/vault_lookup/lookup.rb
@@ -148,7 +148,7 @@ Puppet::Functions.create_function(:'vault_lookup::lookup') do
     end
     begin
       if key.nil?
-        JSON.parse(secret_response.body)['data']
+        JSON.parse(secret_response.body)['data']['data']
       else
         JSON.parse(secret_response.body)['data']['data'][key]
       end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
This PR harmonize `get_secret` return value by only giving the user the data part instead of all the metadata when specifying no `key`.
This behavior is already implemented when we want to extract a specific key of the secret.

#### This Pull Request (PR) fixes the following issues
n.a
