### PR TITLE
allow autogenerate of new secrets if missing

### DIFF
--- a/lib/puppet/functions/vault_lookup/lookup.rb
+++ b/lib/puppet/functions/vault_lookup/lookup.rb
@@ -16,6 +16,7 @@ Puppet::Functions.create_function(:'vault_lookup::lookup', Puppet::Functions::In
     optional_param 'String', :secret_id
     optional_param 'Optional[String]', :approle_path_segment
     optional_param 'String', :agent_sink_file
+    optional_param 'Optional[Integer]', :gen_secret_len
     return_type 'Sensitive'
   end
 
@@ -50,7 +51,8 @@ Puppet::Functions.create_function(:'vault_lookup::lookup', Puppet::Functions::In
                                         role_id: options['role_id'],
                                         secret_id: options['secret_id'],
                                         approle_path_segment: options['approle_path_segment'],
-                                        agent_sink_file: options['agent_sink_file'])
+                                        agent_sink_file: options['agent_sink_file'],
+                                        gen_secret_len: options['gen_secret_len'])
   end
 
   # Lookup with a path and positional arguments.
@@ -68,7 +70,8 @@ Puppet::Functions.create_function(:'vault_lookup::lookup', Puppet::Functions::In
              role_id = nil,
              secret_id = nil,
              approle_path_segment = nil,
-             agent_sink_file = nil)
+             agent_sink_file = nil,
+             gen_secret_len = nil)
 
     PuppetX::VaultLookup::Lookup.lookup(cache: cache,
                                         path: path,
@@ -81,6 +84,7 @@ Puppet::Functions.create_function(:'vault_lookup::lookup', Puppet::Functions::In
                                         role_id: role_id,
                                         secret_id: secret_id,
                                         approle_path_segment: approle_path_segment,
-                                        agent_sink_file: agent_sink_file)
+                                        agent_sink_file: agent_sink_file,
+                                        gen_secret_len: gen_secret_len)
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description
This PR adds a new optional parameter `gen_secret_len`.

If set it will create a new random secret for the specified vault-key with the supplied length

#### This Pull Request (PR) fixes the following issues
Fixes #9 
