### PR TITLE
make webrick optional in sync.yml

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -2,7 +2,7 @@
 .github/workflows/ci.yml:
   unmanaged: true
 Gemfile:
-  required:
+  optional:
     ':test':
       - gem: webrick
         ruby-operator: '>='


### PR DESCRIPTION
This fixes a problem that occurs when trying to use msync on this module. The sync.yml forces a complete override of the Gemfile, breaking the CI. By making it optional the webrick gem only gets added but does not replace the whole file.