### PR TITLE
Allow the user to prevent the lookup from raising an exception

### DIFF
--- a/lib/puppet/functions/vault_lookup/lookup.rb
+++ b/lib/puppet/functions/vault_lookup/lookup.rb
@@ -16,6 +16,7 @@ Puppet::Functions.create_function(:'vault_lookup::lookup', Puppet::Functions::In
     optional_param 'String', :secret_id
     optional_param 'Optional[String]', :approle_path_segment
     optional_param 'String', :agent_sink_file
+    optional_param 'boolean', :raise_exceptions
     return_type 'Sensitive'
   end
 
@@ -68,7 +69,9 @@ Puppet::Functions.create_function(:'vault_lookup::lookup', Puppet::Functions::In
              role_id = nil,
              secret_id = nil,
              approle_path_segment = nil,
-             agent_sink_file = nil)
+             agent_sink_file = nil,
+             raise_exceptions = true
+             )
 
     PuppetX::VaultLookup::Lookup.lookup(cache: cache,
                                         path: path,
@@ -82,5 +85,10 @@ Puppet::Functions.create_function(:'vault_lookup::lookup', Puppet::Functions::In
                                         secret_id: secret_id,
                                         approle_path_segment: approle_path_segment,
                                         agent_sink_file: agent_sink_file)
+    rescue StandardError => e
+      raise if raise_exceptions
+      Puppet.err(e.message)
+      nil
+    end
   end
 end

--- a/spec/functions/lookup_spec.rb
+++ b/spec/functions/lookup_spec.rb
@@ -27,6 +27,13 @@ describe 'vault_lookup::lookup' do
     end.to raise_error(Puppet::Error, %r{No vault_addr given and VAULT_ADDR env variable not set})
   end
 
+  it 'returns nil instead of raising when raising is disabled' do
+    expect {
+      result = function.execute('/v1/whatever', 'vault.docker', false)
+      expect(result).to be(nil)
+    }.not_to raise_error
+  end
+
   it 'raises a Puppet error when auth fails' do
     vault_server = MockVault.new
     vault_server.mount('/v1/auth/cert/login', AuthFailure)


### PR DESCRIPTION
This is a quick attempt to merge in <https://github.com/voxpupuli/puppet-vault_lookup/pull/12> into the current module world.  It adds a 'raise_exceptions' option to lookup code to fail with an error message rather than failing out of the whole puppet process.  

I haven't tested yet.  Original comments, from @Magisus:

> If a lookup function raises an exception, the whole catalog compilation will fail. This PR adds the ability to configure the lookup to not raise and instead simply log and return nil if it encounters an error, so that the users can structure their manifests to only conditionally depend on the result of the lookup.
> 
> We're not sure if this is useful or not, and are looking for use cases and feedback on the approach.
> 
> Fixes #13