### PR TITLE
feat(ruby): additional namespace parameter for multi-tenancy setups

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,19 @@ below are optional.
 #### Positional Arguments
 
 ```
-vault_lookup::lookup( <path>, [<vault_addr>], [<cert_path_segment>], [<cert_role>], [<namespace>], [<field>], [<auth_method>], [<role_id>], [<secret_id>], [<approle_path_segment>], [<agent_sink_file>] )
+vault_lookup::lookup( <path>, [<vault_addr>], [<cert_path_segment>], [<cert_role>], [<namespace>], [<auth_namespace>], [<field>], [<auth_method>], [<role_id>], [<secret_id>], [<approle_path_segment>], [<agent_sink_file>] )
+```
+
+#### Usage in multi-tenant Vault setup
+
+Some Vault setups allows to obtain the authentication token in a defined namespace and to use it for secret retrieval in other namespaces. In this case you have to provide the namespace for authentication as an additional option:
+
+```
+$vault_conf = {
+  'approle_path_segment' => 'v1/auth/approle/',
+  'namespace'            => 'customer_1',
+  'auth_namespace'       => 'provider_1',
+}
 ```
 
 #### Options Hash

--- a/lib/puppet/functions/vault_lookup/lookup.rb
+++ b/lib/puppet/functions/vault_lookup/lookup.rb
@@ -10,6 +10,7 @@ Puppet::Functions.create_function(:'vault_lookup::lookup', Puppet::Functions::In
     optional_param 'Optional[String]', :cert_path_segment
     optional_param 'String', :cert_role
     optional_param 'String', :namespace
+    optional_param 'Optional[String]', :auth_namespace
     optional_param 'String', :field
     optional_param 'Enum["cert", "approle", "agent", "agent_sink"]', :auth_method
     optional_param 'String', :role_id
@@ -45,6 +46,7 @@ Puppet::Functions.create_function(:'vault_lookup::lookup', Puppet::Functions::In
                                         cert_path_segment: options['cert_path_segment'],
                                         cert_role: options['cert_role'],
                                         namespace: options['namespace'],
+                                        auth_namespace: options['auth_namespace'],
                                         field: options['field'],
                                         auth_method: options['auth_method'],
                                         role_id: options['role_id'],
@@ -63,6 +65,7 @@ Puppet::Functions.create_function(:'vault_lookup::lookup', Puppet::Functions::In
              cert_path_segment = nil,
              cert_role = nil,
              namespace = nil,
+             auth_namespace = nil,
              field = nil,
              auth_method = nil,
              role_id = nil,
@@ -76,6 +79,7 @@ Puppet::Functions.create_function(:'vault_lookup::lookup', Puppet::Functions::In
                                         cert_path_segment: cert_path_segment,
                                         cert_role: cert_role,
                                         namespace: namespace,
+                                        auth_namespace: auth_namespace,
                                         field: field,
                                         auth_method: auth_method,
                                         role_id: role_id,

--- a/lib/puppet_x/vault_lookup/lookup.rb
+++ b/lib/puppet_x/vault_lookup/lookup.rb
@@ -12,6 +12,7 @@ module PuppetX
                       cert_path_segment: nil,
                       cert_role: nil,
                       namespace: nil,
+                      auth_namespace: nil,
                       field: nil,
                       auth_method: nil,
                       role_id: nil,
@@ -42,6 +43,7 @@ module PuppetX
         end
 
         auth_method = ENV.fetch('VAULT_AUTH_METHOD', 'cert') if auth_method.nil?
+        auth_namespace = namespace if auth_namespace.nil?
         role_id = ENV.fetch('VAULT_ROLE_ID', nil) if role_id.nil?
         secret_id = ENV.fetch('VAULT_SECRET_ID', nil) if secret_id.nil?
         cert_path_segment = 'v1/auth/cert/' if cert_path_segment.nil?
@@ -62,7 +64,7 @@ module PuppetX
                                       vault_base_uri,
                                       cert_path_segment,
                                       cert_role,
-                                      namespace)
+                                      auth_namespace)
         when 'approle'
           raise Puppet::Error, 'role_id and VAULT_ROLE_ID are both nil' if role_id.nil?
           raise Puppet::Error, 'secret_id and VAULT_SECRET_ID are both nil' if secret_id.nil?
@@ -72,7 +74,7 @@ module PuppetX
                                          approle_path_segment,
                                          role_id,
                                          secret_id,
-                                         namespace)
+                                         auth_namespace)
         when 'agent'
           # Setting the token to nil causes the 'X-Vault-Token' header to not be
           # added by this function when making requests to Vault. Instead, we're

--- a/spec/functions/lookup_spec.rb
+++ b/spec/functions/lookup_spec.rb
@@ -96,7 +96,7 @@ describe 'vault_lookup::lookup' do
     vault_server.mount("/#{custom_auth_segment}/login", AuthSuccess)
     vault_server.mount('/v1/kv/test', SecretLookupSuccessKV2)
     vault_server.start_vault do |port|
-      result = function.execute('kv/test', "http://127.0.0.1:#{port}", custom_auth_segment, '', '', 'bar')
+      result = function.execute('kv/test', "http://127.0.0.1:#{port}", custom_auth_segment, '', '', '', 'bar')
       expect(result).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
       expect(result.unwrap).to eq('baz')
 
@@ -193,16 +193,18 @@ describe 'vault_lookup::lookup' do
     vault_server.mount('/v1/auth/cert/login', AuthSuccess)
     vault_server.mount('/v1/kv/test', SecretLookupSuccess)
     vault_server.start_vault do |port|
-      allow(PuppetX::VaultLookup::Lookup).to receive(:get_secret).and_call_original.exactly(3).times
+      allow(PuppetX::VaultLookup::Lookup).to receive(:get_secret).and_call_original.exactly(4).times
       result1 = function.execute('kv/test', 'vault_addr' => "http://127.0.0.1:#{port}", 'namespace' => 'foo')
       result2 = function.execute('kv/test', 'vault_addr' => "http://127.0.0.1:#{port}", 'namespace' => 'bar')
       result3 = function.execute('kv/test', 'vault_addr' => "http://127.0.0.1:#{port}", 'namespace' => 'baz')
+      result4 = function.execute('kv/test', 'vault_addr' => "http://127.0.0.1:#{port}", 'namespace' => 'qux', 'auth_namespace' => 'quux')
 
       expect(result1).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
       expect(result2).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
       expect(result1.unwrap).to eq('foo' => 'bar')
       expect(result1.unwrap).to eq(result2.unwrap)
       expect(result1.unwrap).to eq(result3.unwrap)
+      expect(result1.unwrap).to eq(result4.unwrap)
     end
   end
 
@@ -226,7 +228,7 @@ describe 'vault_lookup::lookup' do
     end
   end
 
-  context 'when using the agent_sing auth method' do
+  context 'when using the agent_sink auth method' do
     let(:agent_sink_file) { '/tmp/vault_agent_sink' }
 
     it 'errors when token sink file does not exist' do


### PR DESCRIPTION
#### Pull Request (PR) description
In a multi-tenancy Vault setup the namespaces for authentication and secret retrieval can differ.
This PR provides an additional optional parameter for authentication namespace.
